### PR TITLE
Adding test coverage metric with eslint refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 node_modules
 npm-debug.log
+.nyc_output

--- a/eslint_ecma5.json
+++ b/eslint_ecma5.json
@@ -10,7 +10,7 @@
     "camelcase": [2, {"properties": "always"}],
     "eqeqeq": 2,
     "no-eq-null": 1,
-    "indent": ["error", 2],
+    "indent": ["error", "tab"],
     "no-use-before-define": 1,
     "new-cap": 1,
     "quotes": ["error", "single", { "avoidEscape": true }],

--- a/eslint_ecma5.json
+++ b/eslint_ecma5.json
@@ -7,14 +7,14 @@
     }
   },
   "rules": {
-    "camelcase": [2, {"properties": "always"}],
-    "eqeqeq": 2,
-    "no-eq-null": 1,
+    "camelcase": ["error", {"properties": "always"}],
+    "eqeqeq": ["error", "always"],
+    "no-eq-null": "error",
     "indent": ["error", "tab"],
-    "no-use-before-define": 1,
-    "new-cap": 1,
+    "no-use-before-define": "error",
+    "new-cap": ["error", { "newIsCap": true }],
     "quotes": ["error", "single", { "avoidEscape": true }],
-    "no-undef": 2,
+    "no-undef": "error",
     "no-unused-vars": ["error", { "vars": "all", "args": "after-used" }],
     "strict": ["error", "global"]
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "js-nacl": "LiskHQ/js-nacl#6dc1417"
   },
   "devDependencies": {
-    "eslint": "=3.14.1",
     "grunt": "=0.4.5",
     "grunt-browserify": "=5.0.0",
     "grunt-contrib-nodeunit": "=0.4.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "JavaScript library for sending Lisk transactions from the client or server",
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
+    "test": "nyc mocha",
     "preinstall": "npm install -g grunt-cli"
   },
   "repository": {
@@ -28,6 +28,7 @@
     "grunt-contrib-uglify": "=0.5.0",
     "grunt-eslint": "=19.0.0",
     "load-grunt-tasks": "=3.5.2",
+    "nyc": "=10.1.2",
     "should": "=11.1.0"
   }
 }


### PR DESCRIPTION
Integrating Istanbul coverage metric.

Updating package.json dependencies.

As mentioned in Issue #10

Refining rules defined in `eslint_ecma5.json`.