### PR TITLE
Add ports to testnet and ssl in lisk.api().listPeers() - Closes #93

### DIFF
--- a/lib/api/liskApi.js
+++ b/lib/api/liskApi.js
@@ -94,8 +94,8 @@ LiskAPI.prototype.listPeers = function () {
 
 	return {
 		official: this.defaultPeers.map(function(node) { return {node: node};}),
-		ssl: this.defaultSSLPeers.map(function(node) { return {node: node, ssl: true};}),
-		testnet: this.defaultTestnetPeers.map(function(node) { return {node: node, testnet: true};}),
+		ssl: this.defaultSSLPeers.map(function(node) { return {node: node, ssl: true, port: 443};}),
+		testnet: this.defaultTestnetPeers.map(function(node) { return {node: node, testnet: true, port:7000};}),
 	};
 
 };

--- a/lib/api/liskApi.js
+++ b/lib/api/liskApi.js
@@ -95,7 +95,7 @@ LiskAPI.prototype.listPeers = function () {
 	return {
 		official: this.defaultPeers.map(function(node) { return {node: node};}),
 		ssl: this.defaultSSLPeers.map(function(node) { return {node: node, ssl: true, port: 443};}),
-		testnet: this.defaultTestnetPeers.map(function(node) { return {node: node, testnet: true, port:7000};}),
+		testnet: this.defaultTestnetPeers.map(function(node) { return {node: node, testnet: true, port: 7000};}),
 	};
 
 };


### PR DESCRIPTION
Closes #93

Needed for https://github.com/LiskHQ/lisk-nano/issues/106