### PR TITLE
Remove crypto stubbing - Closes #354

### DIFF
--- a/src/transactions/multisignature.js
+++ b/src/transactions/multisignature.js
@@ -55,18 +55,6 @@ function createTransaction(
 }
 
 /**
- * @method signTransaction
- * @param trs transaction object
- * @param secret
- *
- * @return {string}
- */
-
-function signTransaction(trs, secret) {
-	return cryptoModule.multiSignTransaction(trs, secret);
-}
-
-/**
  * @method createMultisignature
  * @param secret string
  * @param secondSecret string
@@ -102,7 +90,6 @@ function createMultisignature(secret, secondSecret, keysgroup, lifetime, min, ti
 }
 
 module.exports = {
-	signTransaction,
 	createMultisignature,
 	createTransaction,
 };

--- a/test/transactions/dapp.js
+++ b/test/transactions/dapp.js
@@ -13,8 +13,8 @@
  *
  */
 import dapp from '../../src/transactions/dapp';
-import slots from '../../src/time/slots';
 import cryptoModule from '../../src/crypto';
+import slots from '../../src/time/slots';
 
 describe('dapp module', () => {
 	describe('exports', () => {

--- a/test/transactions/delegate.js
+++ b/test/transactions/delegate.js
@@ -13,8 +13,8 @@
  *
  */
 import delegate from '../../src/transactions/delegate';
-import slots from '../../src/time/slots';
 import cryptoModule from '../../src/crypto';
+import slots from '../../src/time/slots';
 
 describe('delegate module', () => {
 	describe('exports', () => {

--- a/test/transactions/multisignature.js
+++ b/test/transactions/multisignature.js
@@ -44,10 +44,6 @@ describe('multisignature module', () => {
 			(multisignature).should.be.type('object');
 		});
 
-		it('should export signTransaction function', () => {
-			(multisignature).should.have.property('signTransaction').be.type('function');
-		});
-
 		it('should export createMultisignature function', () => {
 			(multisignature).should.have.property('createMultisignature').be.type('function');
 		});
@@ -336,50 +332,6 @@ describe('multisignature module', () => {
 					(result).should.not.be.ok();
 				});
 			});
-		});
-	});
-
-	describe('#signTransaction', () => {
-		const { signTransaction } = multisignature;
-		const transaction = {
-			type: 0,
-			amount: 10e8,
-			fee: 0.1e8,
-			recipientId: '58191285901858109L',
-			timestamp: 35593081,
-			asset: {},
-			senderPublicKey: '5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09',
-			signature: 'cc1dc3ee73022ed7c10bdfff9183d93e71bd503e57078c32b8e6582bd13450fd9f113f95b101a568b9c757f7e739f15ed9cc77ca7dede62c61f358e30f9dc80d',
-			id: '4758205935095999374',
-		};
-		const signature = '78a09cf9804efdae4f70d2d0ffd66aa063ebf24bd7703dab968dd5f5eeb112cc24d6d25e47d627b1f33ecdf65475cc496bd36ebd590c8216b49977670dcb8f0f';
-		const length = 128; // crypto_sign_BYTES length
-
-		let cryptoGetKeysStub;
-		let cryptoMultiSignStub;
-		let signedTransaction;
-
-		beforeEach(() => {
-			cryptoGetKeysStub = sinon.stub(cryptoModule, 'getKeys').returns(keys);
-			cryptoMultiSignStub = sinon.stub(cryptoModule, 'multiSignTransaction').returns(signature);
-			signedTransaction = signTransaction(transaction, secret);
-		});
-
-		afterEach(() => {
-			cryptoGetKeysStub.restore();
-			cryptoMultiSignStub.restore();
-		});
-
-		it('should return a hex string', () => {
-			(signedTransaction).should.be.a.hexString();
-		});
-
-		it('should have a fixed signature length of 128 bytes', () => {
-			(signedTransaction).should.have.lengthOf(length);
-		});
-
-		it('should use crypto.multiSignTransaction to get the signature', () => {
-			(cryptoMultiSignStub.calledWithExactly(transaction, secret)).should.be.true();
 		});
 	});
 });

--- a/test/transactions/signature.js
+++ b/test/transactions/signature.js
@@ -35,21 +35,17 @@ describe('signature module', () => {
 		const secondPublicKey = '0401c8ac9f29ded9e1e4d5b6b43051cb25b22f27c7b7b35092161e851946f82f';
 		const emptyStringPublicKey = 'be907b4bac84fee5ce8811db2defc9bf0b2a2a2bbc3d54d8a2257ecd70441962';
 		const signatureFee = 5e8;
-		const address = '18160565574430594874L';
 		const timeWithOffset = 38350076;
 
-		let getAddressStub;
 		let getTimeWithOffsetStub;
 		let signatureTransaction;
 
 		beforeEach(() => {
-			getAddressStub = sinon.stub(cryptoModule, 'getAddress').returns(address);
 			getTimeWithOffsetStub = sinon.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
 			signatureTransaction = createSignature(secret, secondSecret);
 		});
 
 		afterEach(() => {
-			getAddressStub.restore();
 			getTimeWithOffsetStub.restore();
 		});
 

--- a/test/transactions/transaction.js
+++ b/test/transactions/transaction.js
@@ -13,8 +13,8 @@
  *
  */
 import transaction from '../../src/transactions/transaction';
-import slots from '../../src/time/slots';
 import cryptoModule from '../../src/crypto';
+import slots from '../../src/time/slots';
 
 describe('transaction module', () => {
 	describe('exports', () => {

--- a/test/transactions/vote.js
+++ b/test/transactions/vote.js
@@ -37,17 +37,14 @@ describe('vote module', () => {
 		const address = '18160565574430594874L';
 		const timeWithOffset = 38350076;
 
-		let getAddressStub;
 		let getTimeWithOffsetStub;
 		let voteTransaction;
 
 		beforeEach(() => {
-			getAddressStub = sinon.stub(cryptoModule, 'getAddress').returns(address);
 			getTimeWithOffsetStub = sinon.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
 		});
 
 		afterEach(() => {
-			getAddressStub.restore();
 			getTimeWithOffsetStub.restore();
 		});
 
@@ -58,10 +55,6 @@ describe('vote module', () => {
 
 			it('should create a vote transaction', () => {
 				(voteTransaction).should.be.ok();
-			});
-
-			it('should use crypto.getAddress to calculate the recipient id', () => {
-				(getAddressStub.calledWithExactly(publicKey)).should.be.true();
 			});
 
 			it('should use slots.getTimeWithOffset to calculate the timestamp', () => {


### PR DESCRIPTION
Closes #354 
This PR removes the `signTransaction` function from the `multisignature` transaction creation module so I didn't have to refactor the tests. It's just a wrapper for a crypto function, and we don't have an analogue in any of the other transaction creators.