### PR TITLE
Use sinon sandboxes - Closes #365

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -3,6 +3,7 @@
 		"mocha": true
 	},
 	"globals": {
+		"sandbox": true,
 		"should": true,
 		"sinon": true
 	},

--- a/test/api/liskApi.js
+++ b/test/api/liskApi.js
@@ -16,6 +16,8 @@ import LiskAPI from '../../src/api/liskApi';
 import privateApi from '../../src/api/privateApi';
 import utils from '../../src/api/utils';
 
+afterEach(() => sandbox.restore());
+
 describe('Lisk API module', () => {
 	const fixedPoint = 10 ** 8;
 	const testPort = 7000;
@@ -70,34 +72,25 @@ describe('Lisk API module', () => {
 	let LSK;
 
 	beforeEach(() => {
-		selectNodeStub = sinon
+		selectNodeStub = sandbox
 			.stub(privateApi, 'selectNode')
 			.returns(defaultSelectedNode);
-		sendRequestPromiseStub = sinon
+		sendRequestPromiseStub = sandbox
 			.stub(privateApi, 'sendRequestPromise')
 			.resolves(Object.assign({}, defaultRequestPromiseResult));
-		checkOptionsStub = sinon
+		checkOptionsStub = sandbox
 			.stub(utils, 'checkOptions')
 			.returns(Object.assign({}, defaultCheckedOptions));
-		handleTimestampIsInFutureFailuresStub = sinon
+		handleTimestampIsInFutureFailuresStub = sandbox
 			.stub(privateApi, 'handleTimestampIsInFutureFailures')
 			.resolves(Object.assign({}, defaultRequestPromiseResult.body));
-		handleSendRequestFailuresStub = sinon
+		handleSendRequestFailuresStub = sandbox
 			.stub(privateApi, 'handleSendRequestFailures');
-		getFullURLStub = sinon
+		getFullURLStub = sandbox
 			.stub(privateApi, 'getFullURL')
 			.returns(defaultUrl);
 
 		LSK = new LiskAPI();
-	});
-
-	afterEach(() => {
-		selectNodeStub.restore();
-		sendRequestPromiseStub.restore();
-		checkOptionsStub.restore();
-		handleTimestampIsInFutureFailuresStub.restore();
-		handleSendRequestFailuresStub.restore();
-		getFullURLStub.restore();
 	});
 
 	describe('LiskAPI()', () => {
@@ -482,15 +475,10 @@ describe('Lisk API module', () => {
 
 	describe('API methods', () => {
 		let callback;
-		let sendRequestStub;
 
 		beforeEach(() => {
 			callback = () => {};
-			sendRequestStub = sinon.stub(LSK, 'sendRequest');
-		});
-
-		afterEach(() => {
-			sendRequestStub.restore();
+			sandbox.stub(LSK, 'sendRequest');
 		});
 
 		describe('#getAccount', () => {

--- a/test/api/privateApi.js
+++ b/test/api/privateApi.js
@@ -15,6 +15,8 @@
 import { PopsicleError } from 'popsicle';
 import privateApi from '../../src/api/privateApi';
 
+afterEach(() => sandbox.restore());
+
 describe('privateApi module', () => {
 	const port = 7000;
 	const localNode = 'localhost';
@@ -60,11 +62,7 @@ describe('privateApi module', () => {
 			sendRequest: () => {},
 		};
 		sendRequestResult = { success: true, sendRequest: true };
-		sendRequestStub = sinon.stub(LSK, 'sendRequest').resolves(Object.assign({}, sendRequestResult));
-	});
-
-	afterEach(() => {
-		sendRequestStub.restore();
+		sendRequestStub = sandbox.stub(LSK, 'sendRequest').resolves(Object.assign({}, sendRequestResult));
 	});
 
 	describe('#netHashOptions', () => {
@@ -122,7 +120,7 @@ describe('privateApi module', () => {
 		let result;
 
 		beforeEach(() => {
-			getURLPrefixStub = sinon.stub().returns(URLPrefix);
+			getURLPrefixStub = sandbox.stub().returns(URLPrefix);
 			// eslint-disable-next-line no-underscore-dangle
 			restoreGetURLPrefixStub = privateApi.__set__('getURLPrefix', getURLPrefixStub);
 			result = getFullURL.call(LSK);
@@ -193,7 +191,7 @@ describe('privateApi module', () => {
 		let restoreGetPeersStub;
 
 		beforeEach(() => {
-			getPeersStub = sinon.stub().returns([].concat(defaultPeers));
+			getPeersStub = sandbox.stub().returns([].concat(defaultPeers));
 			// eslint-disable-next-line no-underscore-dangle
 			restoreGetPeersStub = privateApi.__set__('getPeers', getPeersStub);
 		});
@@ -236,7 +234,7 @@ describe('privateApi module', () => {
 		let restoreGetRandomPeer;
 
 		beforeEach(() => {
-			getRandomPeerStub = sinon.stub().returns(getRandomPeerResult);
+			getRandomPeerStub = sandbox.stub().returns(getRandomPeerResult);
 			// eslint-disable-next-line no-underscore-dangle
 			restoreGetRandomPeer = privateApi.__set__('getRandomPeer', getRandomPeerStub);
 		});
@@ -342,21 +340,18 @@ describe('privateApi module', () => {
 		const { checkReDial } = privateApi;
 		let getPeersStub;
 		let restoreGetPeersStub;
-		let netHashOptionsStub;
 		let setTestnetStub;
 
 		beforeEach(() => {
-			getPeersStub = sinon.stub().returns([].concat(defaultPeers));
+			getPeersStub = sandbox.stub().returns([].concat(defaultPeers));
 			// eslint-disable-next-line no-underscore-dangle
 			restoreGetPeersStub = privateApi.__set__('getPeers', getPeersStub);
-			netHashOptionsStub = sinon.stub(privateApi, 'netHashOptions');
-			setTestnetStub = sinon.stub(LSK, 'setTestnet');
+			sandbox.stub(privateApi, 'netHashOptions');
+			setTestnetStub = sandbox.stub(LSK, 'setTestnet');
 		});
 
 		afterEach(() => {
 			restoreGetPeersStub();
-			netHashOptionsStub.restore();
-			setTestnetStub.restore();
 		});
 
 		describe('with random peer', () => {
@@ -518,7 +513,9 @@ describe('privateApi module', () => {
 				headers: {},
 				body: {},
 			};
-			createRequestObjectStub = sinon.stub().returns(Object.assign({}, createRequestObjectResult));
+			createRequestObjectStub = sandbox
+				.stub()
+				.returns(Object.assign({}, createRequestObjectResult));
 			// eslint-disable-next-line no-underscore-dangle
 			restoreCreateRequestObject = privateApi.__set__('createRequestObject', createRequestObjectStub);
 			sendRequestPromiseResult = sendRequestPromise
@@ -639,20 +636,19 @@ describe('privateApi module', () => {
 				key2: 2,
 			};
 			error = new Error('Test error.');
-			setNodeSpy = sinon.spy(LSK, 'setNode');
-			banNodeSpy = sinon.spy();
+			setNodeSpy = sandbox.spy(LSK, 'setNode');
+			banNodeSpy = sandbox.spy();
 			// eslint-disable-next-line no-underscore-dangle
 			restoreBanNodeSpy = privateApi.__set__('banNode', banNodeSpy);
 		});
 
 		afterEach(() => {
-			setNodeSpy.restore();
 			restoreBanNodeSpy();
 		});
 
 		describe('if a redial is possible', () => {
 			beforeEach(() => {
-				checkReDialStub = sinon.stub().returns(true);
+				checkReDialStub = sandbox.stub().returns(true);
 				// eslint-disable-next-line no-underscore-dangle
 				restoreCheckReDialStub = privateApi.__set__('checkReDial', checkReDialStub);
 			});
@@ -702,11 +698,7 @@ describe('privateApi module', () => {
 
 		describe('if no redial is possible', () => {
 			beforeEach(() => {
-				checkReDialStub = sinon.stub(privateApi, 'checkReDial').returns(false);
-			});
-
-			afterEach(() => {
-				checkReDialStub.restore();
+				checkReDialStub = sandbox.stub(privateApi, 'checkReDial').returns(false);
 			});
 
 			it('should resolve to an object with success set to false', () => {

--- a/test/api/utils.js
+++ b/test/api/utils.js
@@ -14,6 +14,8 @@
  */
 import utils from '../../src/api/utils';
 
+afterEach(() => sandbox.restore());
+
 describe('api utils module', () => {
 	const POST = 'POST';
 	const defaultMethod = POST;
@@ -28,13 +30,8 @@ describe('api utils module', () => {
 			sendRequest: () => {},
 		};
 		sendRequestResult = { success: true, sendRequest: true };
-		sendRequestStub = sinon.stub(LSK, 'sendRequest').resolves(Object.assign({}, sendRequestResult));
+		sendRequestStub = sandbox.stub(LSK, 'sendRequest').resolves(Object.assign({}, sendRequestResult));
 	});
-
-	afterEach(() => {
-		sendRequestStub.restore();
-	});
-
 
 	describe('exports', () => {
 		it('should be an object', () => {
@@ -175,8 +172,8 @@ describe('api utils module', () => {
 				key5: 'value 5',
 				key6: 6,
 			};
-			getDataFnStub = sinon.stub().returns(Object.assign({}, getDataFnResult));
-			constructRequestDataStub = sinon.stub()
+			getDataFnStub = sandbox.stub().returns(Object.assign({}, getDataFnResult));
+			constructRequestDataStub = sandbox.stub()
 				.returns(Object.assign({}, constructRequestDataResult));
 			// eslint-disable-next-line no-underscore-dangle
 			restoreConstructRequestDataStub = utils.__set__('constructRequestData', constructRequestDataStub);
@@ -281,7 +278,7 @@ describe('api utils module', () => {
 	describe('#optionallyCallCallback', () => {
 		const { optionallyCallCallback } = utils;
 		const result = 'result';
-		const spy = sinon.spy();
+		const spy = sandbox.spy();
 
 		it('should return the result with a callback', () => {
 			const returnValue = optionallyCallCallback(spy, result);

--- a/test/setup.js
+++ b/test/setup.js
@@ -39,6 +39,7 @@ should.use((_, Assertion) => {
 // See https://github.com/shouldjs/should.js/issues/41
 Object.defineProperty(global, 'should', { value: should });
 global.sinon = sinon;
+global.sandbox = sinon.sandbox.create();
 
 naclFactory.instantiate((nacl) => {
 	global.naclInstance = nacl;

--- a/test/transactions/dapp.js
+++ b/test/transactions/dapp.js
@@ -16,6 +16,8 @@ import dapp from '../../src/transactions/dapp';
 import cryptoModule from '../../src/crypto';
 import slots from '../../src/time/slots';
 
+afterEach(() => sandbox.restore());
+
 describe('dapp module', () => {
 	describe('exports', () => {
 		it('should be an object', () => {
@@ -55,12 +57,8 @@ describe('dapp module', () => {
 		let dappTransaction;
 
 		beforeEach(() => {
-			getTimeWithOffsetStub = sinon.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
+			getTimeWithOffsetStub = sandbox.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
 			options = Object.assign({}, defaultOptions);
-		});
-
-		afterEach(() => {
-			getTimeWithOffsetStub.restore();
 		});
 
 		describe('without second secret', () => {

--- a/test/transactions/delegate.js
+++ b/test/transactions/delegate.js
@@ -16,6 +16,8 @@ import delegate from '../../src/transactions/delegate';
 import cryptoModule from '../../src/crypto';
 import slots from '../../src/time/slots';
 
+afterEach(() => sandbox.restore());
+
 describe('delegate module', () => {
 	describe('exports', () => {
 		it('should be an object', () => {
@@ -41,11 +43,7 @@ describe('delegate module', () => {
 		let delegateTransaction;
 
 		beforeEach(() => {
-			getTimeWithOffsetStub = sinon.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
-		});
-
-		afterEach(() => {
-			getTimeWithOffsetStub.restore();
+			getTimeWithOffsetStub = sandbox.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
 		});
 
 		describe('without second secret', () => {

--- a/test/transactions/multisignature.js
+++ b/test/transactions/multisignature.js
@@ -16,6 +16,8 @@ import multisignature from '../../src/transactions/multisignature';
 import cryptoModule from '../../src/crypto';
 import slots from '../../src/time/slots';
 
+afterEach(() => sandbox.restore());
+
 describe('multisignature module', () => {
 	const secret = 'secret';
 	const secondSecret = 'second secret';
@@ -32,11 +34,7 @@ describe('multisignature module', () => {
 	let getTimeWithOffsetStub;
 
 	beforeEach(() => {
-		getTimeWithOffsetStub = sinon.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
-	});
-
-	afterEach(() => {
-		getTimeWithOffsetStub.restore();
+		getTimeWithOffsetStub = sandbox.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
 	});
 
 	describe('exports', () => {

--- a/test/transactions/signature.js
+++ b/test/transactions/signature.js
@@ -16,6 +16,8 @@ import signature from '../../src/transactions/signature';
 import cryptoModule from '../../src/crypto';
 import slots from '../../src/time/slots';
 
+afterEach(() => sandbox.restore());
+
 describe('signature module', () => {
 	describe('exports', () => {
 		it('should be an object', () => {
@@ -41,12 +43,8 @@ describe('signature module', () => {
 		let signatureTransaction;
 
 		beforeEach(() => {
-			getTimeWithOffsetStub = sinon.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
+			getTimeWithOffsetStub = sandbox.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
 			signatureTransaction = createSignature(secret, secondSecret);
-		});
-
-		afterEach(() => {
-			getTimeWithOffsetStub.restore();
 		});
 
 		it('should create a signature transaction', () => {

--- a/test/transactions/transaction.js
+++ b/test/transactions/transaction.js
@@ -16,6 +16,8 @@ import transaction from '../../src/transactions/transaction';
 import cryptoModule from '../../src/crypto';
 import slots from '../../src/time/slots';
 
+afterEach(() => sandbox.restore());
+
 describe('transaction module', () => {
 	describe('exports', () => {
 		it('should be an object', () => {
@@ -46,11 +48,7 @@ describe('transaction module', () => {
 		let transactionTransaction;
 
 		beforeEach(() => {
-			getTimeWithOffsetStub = sinon.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
-		});
-
-		afterEach(() => {
-			getTimeWithOffsetStub.restore();
+			getTimeWithOffsetStub = sandbox.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
 		});
 
 		describe('without second secret', () => {

--- a/test/transactions/transfer.js
+++ b/test/transactions/transfer.js
@@ -16,6 +16,8 @@ import transfer from '../../src/transactions/transfer';
 import cryptoModule from '../../src/crypto';
 import slots from '../../src/time/slots';
 
+afterEach(() => sandbox.restore());
+
 describe('transfer module', () => {
 	const dappId = '1234213';
 	const secret = 'secret';
@@ -30,11 +32,7 @@ describe('transfer module', () => {
 	let getTimeWithOffsetStub;
 
 	beforeEach(() => {
-		getTimeWithOffsetStub = sinon.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
-	});
-
-	afterEach(() => {
-		getTimeWithOffsetStub.restore();
+		getTimeWithOffsetStub = sandbox.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
 	});
 
 	describe('exports', () => {

--- a/test/transactions/vote.js
+++ b/test/transactions/vote.js
@@ -16,6 +16,8 @@ import vote from '../../src/transactions/vote';
 import cryptoModule from '../../src/crypto';
 import slots from '../../src/time/slots';
 
+afterEach(() => sandbox.restore());
+
 describe('vote module', () => {
 	describe('exports', () => {
 		it('should be an object', () => {
@@ -41,11 +43,7 @@ describe('vote module', () => {
 		let voteTransaction;
 
 		beforeEach(() => {
-			getTimeWithOffsetStub = sinon.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
-		});
-
-		afterEach(() => {
-			getTimeWithOffsetStub.restore();
+			getTimeWithOffsetStub = sandbox.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
 		});
 
 		describe('without second secret', () => {


### PR DESCRIPTION
Closes #365 
Couldn't see a way to use fake timers with the sandbox without rewriting the `slots` tests, which is beyond the scope of this issue.
Also, I wanted to just add an `afterEach` hook in `setup.js`, but apparently this is not possible for require'd scripts, which is why there's this `afterEach(() => sandbox.restore());` at the top of each relevant test file. See https://github.com/mochajs/mocha/issues/764