### PR TITLE
Code of Conduct Link Update in ISSUE_TEMPLATE.md (Relative Notation) - Fixes #392

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Have you read Lisk-JS's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/lisk-js/master/CODE_OF_CONDUCT.md
+Have you read Lisk-JS's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: [Lisk-JS Code of Conduct](CODE_OF_CONDUCT.md)
 
 ### Description
 


### PR DESCRIPTION
Per discussion in #395, updated the link in ISSUE_TEMPLATE.md with a relative link, based on the one that is in CONTRIBUTING.md (line 24), so that regardless of branch, it will work as long as the file is present in the same branch.