### PR TITLE
Use single options parameter as argument for functions - Close #337

### DIFF
--- a/src/transactions/0_send.js
+++ b/src/transactions/0_send.js
@@ -23,19 +23,20 @@ import { prepareTransaction } from './utils';
 
 /**
  * @method createTransaction
- * @param recipientId
- * @param amount
- * @param secret
- * @param secondSecret
- * @param data
- * @param timeOffset
+ * @param {Object} Object - Object
+ * @param {String} Object.recipientId
+ * @param {String} Object.amoun
+ * @param {String} Object.secret
+ * @param {String} Object.secondSecret
+ * @param {String} Object.data
+ * @param {Number} Object.timeOffset
  *
  * @return {Object}
  */
 
-export default function send(
+export default function send({
 	recipientId, amount, secret, secondSecret, data, timeOffset,
-) {
+}) {
 	const keys = cryptoModule.getKeys(secret);
 	const fee = data ? (SEND_FEE + DATA_FEE) : SEND_FEE;
 	const transaction = {

--- a/src/transactions/0_send.js
+++ b/src/transactions/0_send.js
@@ -25,7 +25,7 @@ import { prepareTransaction } from './utils';
  * @method createTransaction
  * @param {Object} Object - Object
  * @param {String} Object.recipientId
- * @param {Number} Object.amount
+ * @param {String} Object.amount
  * @param {String} Object.secret
  * @param {String} Object.secondSecret
  * @param {String} Object.data

--- a/src/transactions/0_send.js
+++ b/src/transactions/0_send.js
@@ -25,7 +25,7 @@ import { prepareTransaction } from './utils';
  * @method createTransaction
  * @param {Object} Object - Object
  * @param {String} Object.recipientId
- * @param {String} Object.amoun
+ * @param {Number} Object.amount
  * @param {String} Object.secret
  * @param {String} Object.secondSecret
  * @param {String} Object.data

--- a/src/transactions/0_sendFromMultisignatureAccount.js
+++ b/src/transactions/0_sendFromMultisignatureAccount.js
@@ -23,20 +23,21 @@ import slots from '../time/slots';
 import { prepareTransaction } from './utils';
 
 /**
- * @method createTransaction
- * @param recipientId string
- * @param amount number
- * @param secret secret
- * @param secondSecret secret
- * @param requesterPublicKey string
- * @param timeOffset number
+ * @method sendFromMultisignatureAccount
+ * @param {Object} Object - Object
+ * @param {String} Object.recipientId
+ * @param {Number} Object.amount
+ * @param {String} Object.secret
+ * @param {String} Object.secondSecret
+ * @param {String} Object.requesterPublicKey
+ * @param {Number} Object.timeOffset
  *
- * @return {string}
+ * @return {Object}
  */
 
-export default function sendFromMultisignatureAccount(
+export default function sendFromMultisignatureAccount({
 	recipientId, amount, secret, secondSecret, requesterPublicKey, timeOffset,
-) {
+}) {
 	const keys = cryptoModule.getKeys(secret);
 
 	const transaction = {

--- a/src/transactions/1_registerSecondSignature.js
+++ b/src/transactions/1_registerSecondSignature.js
@@ -34,15 +34,16 @@ function newSignature(secondSecret) {
 }
 
 /**
- * @method createSignature
- * @param secret
- * @param secondSecret
- * @param timeOffset
+ * @method registerSecondSignature
+ * @param {Object} Object - Object
+ * @param {String} Object.secret
+ * @param {String} Object.secondSecret
+ * @param {Number} Object.timeOffset
  *
  * @return {Object}
  */
 
-export default function registerSecondSignature(secret, secondSecret, timeOffset) {
+export default function registerSecondSignature({ secret, secondSecret, timeOffset }) {
 	const keys = cryptoModule.getKeys(secret);
 
 	const signature = newSignature(secondSecret);

--- a/src/transactions/2_registerDelegate.js
+++ b/src/transactions/2_registerDelegate.js
@@ -22,16 +22,17 @@ import slots from '../time/slots';
 import { prepareTransaction } from './utils';
 
 /**
- * @method createDapp
- * @param secret
- * @param username
- * @param secondSecret
- * @param timeOffset
+ * @method registerDelegate
+ * @param {Object} Object - Object
+ * @param {String} Object.secret
+ * @param {String} Object.username
+ * @param {String} Object.secondSecret
+ * @param {Number} Object.timeOffset
  *
  * @return {Object}
  */
 
-export default function registerDelegate(secret, username, secondSecret, timeOffset) {
+export default function registerDelegate({ secret, username, secondSecret, timeOffset }) {
 	const keys = cryptoModule.getKeys(secret);
 
 	const transaction = {

--- a/src/transactions/3_castVotes.js
+++ b/src/transactions/3_castVotes.js
@@ -22,16 +22,17 @@ import slots from '../time/slots';
 import { prepareTransaction } from './utils';
 
 /**
- * @method createVote
- * @param secret
- * @param delegates
- * @param secondSecret
- * @param timeOffset
+ * @method createVotes
+ * @param {Object} Object - Object
+ * @param {String} Object.secret
+ * @param {Array<Object>} Object.delegates
+ * @param {String} Object.secondSecret
+ * @param {Number} Object.timeOffset
  *
  * @return {Object}
  */
 
-export default function castVotes(secret, delegates, secondSecret, timeOffset) {
+export default function castVotes({ secret, delegates, secondSecret, timeOffset }) {
 	const keys = cryptoModule.getKeys(secret);
 
 	const transaction = {

--- a/src/transactions/3_castVotes.js
+++ b/src/transactions/3_castVotes.js
@@ -22,10 +22,10 @@ import slots from '../time/slots';
 import { prepareTransaction } from './utils';
 
 /**
- * @method createVotes
+ * @method castVotes
  * @param {Object} Object - Object
  * @param {String} Object.secret
- * @param {Array<Object>} Object.delegates
+ * @param {Array<String>} Object.delegates
  * @param {String} Object.secondSecret
  * @param {Number} Object.timeOffset
  *

--- a/src/transactions/4_registerMultisignatureAccount.js
+++ b/src/transactions/4_registerMultisignatureAccount.js
@@ -17,20 +17,21 @@ import { MULTISIGNATURE_FEE } from '../constants';
 import slots from '../time/slots';
 import { prepareTransaction } from './utils';
 /**
- * @method createMultisignature
- * @param secret string
- * @param secondSecret string
- * @param keysgroup array
- * @param lifetime number
- * @param min number
- * @param timeOffset number
+ * @method registerMultisignatureAccount
+ * @param {Object} Object - Object
+ * @param {String} Object.secret
+ * @param {String} Object.secondSecret
+ * @param {Array<String>} Object.keysgroup
+ * @param {Number} Object.lifetime
+ * @param {Number} Object.min
+ * @param {Number} Object.timeOffset
  *
  * @return {Object}
  */
 
-export default function registerMultisignatureAccount(
+export default function registerMultisignatureAccount({
 	secret, secondSecret, keysgroup, lifetime, min, timeOffset,
-) {
+}) {
 	const keys = cryptoModule.getKeys(secret);
 	const keygroupFees = keysgroup.length + 1;
 

--- a/src/transactions/5_createDapp.js
+++ b/src/transactions/5_createDapp.js
@@ -45,15 +45,16 @@ const validateOptions = (options) => {
 
 /**
  * @method createDapp
- * @param secret
- * @param secondSecret
- * @param options
- * @param timeOffset
+ * @param {Object} Object - Object
+ * @param {String} Object.secret
+ * @param {String} Object.secondSecret
+ * @param {Object} Object.options
+ * @param {Number} Objec.timeOffset
  *
  * @return {Object}
  */
 
-export default function createDapp(secret, secondSecret, options, timeOffset) {
+export default function createDapp({ secret, secondSecret, options, timeOffset }) {
 	validateOptions(options);
 
 	const keys = cryptoModule.getKeys(secret);

--- a/src/transactions/6_transferIntoDapp.js
+++ b/src/transactions/6_transferIntoDapp.js
@@ -23,17 +23,18 @@ import slots from '../time/slots';
 import { prepareTransaction } from './utils';
 
 /**
- * @method createInTransfer
- * @param dappId
- * @param amount
- * @param secret
- * @param secondSecret
- * @param timeOffset
+ * @method transferIntoDapp
+ * @param {Object} Object - Object
+ * @param {String} Object.dappId
+ * @param {Number} Object.amount
+ * @param {String} Object.secret
+ * @param {String} Object.secondSecret
+ * @param {Number} Object.timeOffset
  *
  * @return {Object}
  */
 
-export default function transferIntoDapp(dappId, amount, secret, secondSecret, timeOffset) {
+export default function transferIntoDapp({ dappId, amount, secret, secondSecret, timeOffset }) {
 	const keys = cryptoModule.getKeys(secret);
 
 	const transaction = {

--- a/src/transactions/7_transferOutOfDapp.js
+++ b/src/transactions/7_transferOutOfDapp.js
@@ -23,21 +23,22 @@ import slots from '../time/slots';
 import { prepareTransaction } from './utils';
 
 /**
- * @method createOutTransfer
- * @param dappId
- * @param transactionId
- * @param recipientId
- * @param amount
- * @param secret
- * @param secondSecret
- * @param timeOffset
+ * @method transferOutOfDapp
+ * @param {Object} Object - Object
+ * @param {String} Object.dappId
+ * @param {String} Object.transactionId
+ * @param {String} Object.recipientId
+ * @param {Number} Object.amount
+ * @param {String} Object.secret
+ * @param {String} Object.secondSecret
+ * @param {Number} Object.timeOffset
  *
  * @return {Object}
  */
 
-export default function transferOutOfDapp(
+export default function transferOutOfDapp({
 	dappId, transactionId, recipientId, amount, secret, secondSecret, timeOffset,
-) {
+}) {
 	const keys = cryptoModule.getKeys(secret);
 
 	const transaction = {

--- a/test/transactions/0_send.js
+++ b/test/transactions/0_send.js
@@ -20,14 +20,14 @@ afterEach(() => sandbox.restore());
 
 describe('#send transaction', () => {
 	const fixedPoint = 10 ** 8;
-	const recipientAddress = '58191285901858109L';
+	const recipientId = '58191285901858109L';
 	const testData = 'data';
 	const secret = 'secret';
 	const secondSecret = 'second secret';
 	const publicKey = '5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09';
 	const secondPublicKey = '0401c8ac9f29ded9e1e4d5b6b43051cb25b22f27c7b7b35092161e851946f82f';
 	const emptyPublicKey = 'be907b4bac84fee5ce8811db2defc9bf0b2a2a2bbc3d54d8a2257ecd70441962';
-	const testAmount = 1000;
+	const amount = 1000;
 	const sendFee = 0.1 * fixedPoint;
 	const sendWithDataFee = 0.2 * fixedPoint;
 	const timeWithOffset = 38350076;
@@ -42,9 +42,9 @@ describe('#send transaction', () => {
 	describe('without second secret', () => {
 		describe('without data', () => {
 			beforeEach(() => {
-				sendTransaction = send(
-					recipientAddress, testAmount, secret,
-				);
+				sendTransaction = send({
+					recipientId, amount, secret,
+				});
 			});
 
 			it('should create a send transaction', () => {
@@ -57,9 +57,9 @@ describe('#send transaction', () => {
 
 			it('should use slots.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
 				const offset = -10;
-				send(
-					recipientAddress, testAmount, secret, null, null, offset,
-				);
+				send({
+					recipientId, amount, secret, timeOffset: offset,
+				});
 
 				(getTimeWithOffsetStub.calledWithExactly(offset)).should.be.true();
 			});
@@ -78,7 +78,7 @@ describe('#send transaction', () => {
 				});
 
 				it('should have amount number equal to provided amount', () => {
-					(sendTransaction).should.have.property('amount').and.be.type('number').and.equal(testAmount);
+					(sendTransaction).should.have.property('amount').and.be.type('number').and.equal(amount);
 				});
 
 				it('should have fee number equal to send fee', () => {
@@ -86,7 +86,7 @@ describe('#send transaction', () => {
 				});
 
 				it('should have recipientId string equal to provided recipient id', () => {
-					(sendTransaction).should.have.property('recipientId').and.be.type('string').and.equal(recipientAddress);
+					(sendTransaction).should.have.property('recipientId').and.be.type('string').and.equal(recipientId);
 				});
 
 				it('should have senderPublicKey hex string equal to sender public key', () => {
@@ -122,13 +122,13 @@ describe('#send transaction', () => {
 
 		describe('with data', () => {
 			beforeEach(() => {
-				sendTransaction = send(
-					recipientAddress, testAmount, secret, null, testData,
-				);
+				sendTransaction = send({
+					recipientId, amount, secret, data: testData,
+				});
 			});
 
 			it('should handle invalid (non-utf8 string) data', () => {
-				(send.bind(null, recipientAddress, testAmount, secret, null, Buffer.from('hello')))
+				(send.bind(null, { recipientId, amount, secret, data: Buffer.from('hello') }))
 					.should.throw('Invalid encoding in transaction data. Data must be utf-8 encoded.');
 			});
 
@@ -148,27 +148,27 @@ describe('#send transaction', () => {
 
 	describe('with second secret', () => {
 		beforeEach(() => {
-			sendTransaction = send(
-				recipientAddress, testAmount, secret, secondSecret,
-			);
+			sendTransaction = send({
+				recipientId, amount, secret, secondSecret,
+			});
 		});
 
 		it('should create a send transaction', () => {
-			const sendTransactionWithoutSecondSecret = send(
-				recipientAddress, testAmount, secret,
-			);
+			const sendTransactionWithoutSecondSecret = send({
+				recipientId, amount, secret,
+			});
 			(sendTransaction).should.be.ok();
 			(sendTransaction).should.not.be.equal(sendTransactionWithoutSecondSecret);
 		});
 
 		it('should create send transaction with second signature and data', () => {
-			sendTransaction = send(
-				recipientAddress,
-				testAmount,
+			sendTransaction = send({
+				recipientId,
+				amount,
 				secret,
 				secondSecret,
-				testData,
-			);
+				data: testData,
+			});
 			(sendTransaction).should.be.ok();
 		});
 
@@ -184,13 +184,13 @@ describe('#send transaction', () => {
 			});
 
 			it('should be second signed correctly if second signature is an empty string', () => {
-				sendTransaction = send(
-					recipientAddress,
-					testAmount,
+				sendTransaction = send({
+					recipientId,
+					amount,
 					secret,
-					'',
+					secondSecret: '',
 					testData,
-				);
+				});
 				const result = cryptoModule
 					.verifyTransaction(sendTransaction, emptyPublicKey);
 				(result).should.be.ok();

--- a/test/transactions/0_sendFromMultisignatureAccount.js
+++ b/test/transactions/0_sendFromMultisignatureAccount.js
@@ -30,13 +30,12 @@ describe('#sendFromMultisignatureAccount transaction', () => {
 
 	describe('without second secret', () => {
 		beforeEach(() => {
-			sendFromMultisignatureAccountTransaction = sendFromMultisignatureAccount(
+			sendFromMultisignatureAccountTransaction = sendFromMultisignatureAccount({
 				recipientId,
 				amount,
 				secret,
-				null,
 				requesterPublicKey,
-			);
+			});
 		});
 
 		it('should create a send from multisignature transaction', () => {
@@ -49,7 +48,9 @@ describe('#sendFromMultisignatureAccount transaction', () => {
 
 		it('should use slots.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
 			const offset = -10;
-			sendFromMultisignatureAccount(recipientId, amount, secret, null, requesterPublicKey, offset);
+			sendFromMultisignatureAccount({
+				recipientId, amount, secret, requesterPublicKey, timeOffset: offset,
+			});
 
 			(getTimeWithOffsetStub.calledWithExactly(offset)).should.be.true();
 		});
@@ -90,11 +91,11 @@ describe('#sendFromMultisignatureAccount transaction', () => {
 			});
 
 			it('should have requesterPublicKey equal to senderPublicKey', () => {
-				sendFromMultisignatureAccountTransaction = sendFromMultisignatureAccount(
+				sendFromMultisignatureAccountTransaction = sendFromMultisignatureAccount({
 					recipientId,
 					amount,
 					secret,
-				);
+				});
 				(sendFromMultisignatureAccountTransaction.requesterPublicKey).should.be.equal(
 					keys.publicKey,
 				);
@@ -135,24 +136,23 @@ describe('#sendFromMultisignatureAccount transaction', () => {
 
 	describe('with second secret', () => {
 		beforeEach(() => {
-			sendFromMultisignatureAccountTransaction = sendFromMultisignatureAccount(
+			sendFromMultisignatureAccountTransaction = sendFromMultisignatureAccount({
 				recipientId,
 				amount,
 				secret,
 				secondSecret,
 				requesterPublicKey,
-			);
+			});
 		});
 
 		it('should create a multisignature transaction with a second secret', () => {
 			/* eslint-disable max-len */
-			const sendFromMultisignatureAccountTransactionWithoutSecondSecret = sendFromMultisignatureAccount(
+			const sendFromMultisignatureAccountTransactionWithoutSecondSecret = sendFromMultisignatureAccount({
 				recipientId,
 				amount,
 				secret,
-				null,
 				requesterPublicKey,
-			);
+			});
 			(sendFromMultisignatureAccountTransaction).should.be.ok();
 			(sendFromMultisignatureAccountTransaction).should.not.be.equal(
 				sendFromMultisignatureAccountTransactionWithoutSecondSecret,

--- a/test/transactions/1_registerSecondSignature.js
+++ b/test/transactions/1_registerSecondSignature.js
@@ -127,7 +127,7 @@ describe('#registerSecondSignature transaction', () => {
 			});
 
 			it('should have the correct publicKey if the provided second secret is an empty string', () => {
-				registerSecondSignatureTransaction = registerSecondSignature({ secret: 'secret', secondSecret: '' });
+				registerSecondSignatureTransaction = registerSecondSignature({ secret, secondSecret: '' });
 				(registerSecondSignatureTransaction.asset.signature.publicKey).should.be.equal(
 					emptyStringPublicKey,
 				);

--- a/test/transactions/1_registerSecondSignature.js
+++ b/test/transactions/1_registerSecondSignature.js
@@ -32,7 +32,7 @@ describe('#registerSecondSignature transaction', () => {
 
 	beforeEach(() => {
 		getTimeWithOffsetStub = sandbox.stub(slots, 'getTimeWithOffset').returns(timeWithOffset);
-		registerSecondSignatureTransaction = registerSecondSignature(secret, secondSecret);
+		registerSecondSignatureTransaction = registerSecondSignature({ secret, secondSecret });
 	});
 
 	it('should create a register second signature transaction', () => {
@@ -45,7 +45,7 @@ describe('#registerSecondSignature transaction', () => {
 
 	it('should use slots.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
 		const offset = -10;
-		registerSecondSignature(secret, secondSecret, offset);
+		registerSecondSignature({ secret, secondSecret, timeOffset: offset });
 
 		(getTimeWithOffsetStub.calledWithExactly(offset)).should.be.true();
 	});
@@ -127,7 +127,7 @@ describe('#registerSecondSignature transaction', () => {
 			});
 
 			it('should have the correct publicKey if the provided second secret is an empty string', () => {
-				registerSecondSignatureTransaction = registerSecondSignature('secret', '');
+				registerSecondSignatureTransaction = registerSecondSignature({ secret: 'secret', secondSecret: '' });
 				(registerSecondSignatureTransaction.asset.signature.publicKey).should.be.equal(
 					emptyStringPublicKey,
 				);

--- a/test/transactions/2_registerDelegate.js
+++ b/test/transactions/2_registerDelegate.js
@@ -36,7 +36,7 @@ describe('#registerDelegate tranasction', () => {
 
 	describe('without second secret', () => {
 		beforeEach(() => {
-			registerDelegateTransaction = registerDelegate(secret, username);
+			registerDelegateTransaction = registerDelegate({ secret, username });
 		});
 
 		it('should create a register delegate transaction', () => {
@@ -49,7 +49,7 @@ describe('#registerDelegate tranasction', () => {
 
 		it('should use slots.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
 			const offset = -10;
-			registerDelegate(secret, username, null, offset);
+			registerDelegate({ secret, username, timeOffset: offset });
 
 			(getTimeWithOffsetStub.calledWithExactly(offset)).should.be.true();
 		});
@@ -120,11 +120,11 @@ describe('#registerDelegate tranasction', () => {
 
 	describe('with second secret', () => {
 		beforeEach(() => {
-			registerDelegateTransaction = registerDelegate(secret, username, secondSecret);
+			registerDelegateTransaction = registerDelegate({ secret, username, secondSecret });
 		});
 
 		it('should create a delegate transaction with a second secret', () => {
-			const registerDelegateTransactionWithoutSecondSecret = registerDelegate(secret, username);
+			const registerDelegateTransactionWithoutSecondSecret = registerDelegate({ secret, username });
 			(registerDelegateTransaction).should.be.ok();
 			(registerDelegateTransaction).should.not.be.equal(
 				registerDelegateTransactionWithoutSecondSecret,

--- a/test/transactions/3_castVotes.js
+++ b/test/transactions/3_castVotes.js
@@ -36,7 +36,7 @@ describe('#castVotes transaction', () => {
 
 	describe('without second secret', () => {
 		beforeEach(() => {
-			castVotesTransaction = castVotes(secret, publicKeys);
+			castVotesTransaction = castVotes({ secret, delegates: publicKeys });
 		});
 
 		it('should create a cast votes transaction', () => {
@@ -49,7 +49,7 @@ describe('#castVotes transaction', () => {
 
 		it('should use slots.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
 			const offset = -10;
-			castVotes(secret, publicKeys, null, offset);
+			castVotes({ secret, delegates: publicKeys, timeOffset: offset });
 
 			(getTimeWithOffsetStub.calledWithExactly(offset)).should.be.true();
 		});
@@ -136,11 +136,11 @@ describe('#castVotes transaction', () => {
 
 	describe('with second secret', () => {
 		beforeEach(() => {
-			castVotesTransaction = castVotes(secret, publicKeys, secondSecret);
+			castVotesTransaction = castVotes({ secret, delegates: publicKeys, secondSecret });
 		});
 
 		it('should create a vote transaction with a second secret', () => {
-			const castVotesTransactionWithoutSecondSecret = castVotes(secret, publicKeys);
+			const castVotesTransactionWithoutSecondSecret = castVotes({ secret, delegates: publicKeys });
 			(castVotesTransaction).should.be.ok();
 			(castVotesTransaction).should.not.be.equal(castVotesTransactionWithoutSecondSecret);
 		});

--- a/test/transactions/4_registerMultisignatureAccount.js
+++ b/test/transactions/4_registerMultisignatureAccount.js
@@ -44,13 +44,12 @@ describe('#registerMultisignatureAccount transaction', () => {
 
 	describe('without second secret', () => {
 		beforeEach(() => {
-			registerMultisignatureTransaction = registerMultisignatureAccount(
+			registerMultisignatureTransaction = registerMultisignatureAccount({
 				secret,
-				null,
 				keysgroup,
 				lifetime,
 				min,
-			);
+			});
 		});
 
 		it('should create a register multisignature transaction', () => {
@@ -63,7 +62,7 @@ describe('#registerMultisignatureAccount transaction', () => {
 
 		it('should use slots.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
 			const offset = -10;
-			registerMultisignatureAccount(secret, null, keysgroup, lifetime, min, offset);
+			registerMultisignatureAccount({ secret, keysgroup, lifetime, min, timeOffset: offset });
 
 			(getTimeWithOffsetStub.calledWithExactly(offset)).should.be.true();
 		});
@@ -146,15 +145,15 @@ describe('#registerMultisignatureAccount transaction', () => {
 
 	describe('with second secret', () => {
 		beforeEach(() => {
-			registerMultisignatureTransaction = registerMultisignatureAccount(
+			registerMultisignatureTransaction = registerMultisignatureAccount({
 				secret, secondSecret, keysgroup, lifetime, min,
-			);
+			});
 		});
 
 		it('should create a multisignature transaction with a second secret', () => {
-			const registerMultisignatureTransactionWithoutSecondSecret = registerMultisignatureAccount(
+			const registerMultisignatureTransactionWithoutSecondSecret = registerMultisignatureAccount({
 				secret, secondSecret, keysgroup, lifetime, min,
-			);
+			});
 			(registerMultisignatureTransaction).should.be.ok();
 			(registerMultisignatureTransaction)
 				.should.not.be.equal(registerMultisignatureTransactionWithoutSecondSecret);

--- a/test/transactions/5_createDapp.js
+++ b/test/transactions/5_createDapp.js
@@ -51,7 +51,7 @@ describe('#createDapp transaction', () => {
 
 	describe('without second secret', () => {
 		beforeEach(() => {
-			createDappTransaction = createDapp(secret, null, options);
+			createDappTransaction = createDapp({ secret, options });
 		});
 
 		it('should create a create dapp transaction', () => {
@@ -59,52 +59,52 @@ describe('#createDapp transaction', () => {
 		});
 
 		it('should throw an error if no options are provided', () => {
-			(createDapp.bind(null, secret)).should.throw(noOptionsError);
+			(createDapp.bind(null, { secret })).should.throw(noOptionsError);
 		});
 
 		it('should throw an error if no category is provided', () => {
 			delete options.category;
-			(createDapp.bind(null, secret, null, options)).should.throw(categoryIntegerError);
+			(createDapp.bind(null, { secret, options })).should.throw(categoryIntegerError);
 		});
 
 		it('should throw an error if provided category is not an integer', () => {
 			options.category = 'not an integer';
-			(createDapp.bind(null, secret, null, options)).should.throw(categoryIntegerError);
+			(createDapp.bind(null, { secret, options })).should.throw(categoryIntegerError);
 		});
 
 		it('should throw an error if no name is provided', () => {
 			delete options.name;
-			(createDapp.bind(null, secret, null, options)).should.throw(nameStringError);
+			(createDapp.bind(null, { secret, options })).should.throw(nameStringError);
 		});
 
 		it('should throw an error if provided name is not a string', () => {
 			options.name = 123;
-			(createDapp.bind(null, secret, null, options)).should.throw(nameStringError);
+			(createDapp.bind(null, { secret, options })).should.throw(nameStringError);
 		});
 
 		it('should throw an error if no type is provided', () => {
 			delete options.type;
-			(createDapp.bind(null, secret, null, options)).should.throw(typeIntegerError);
+			(createDapp.bind(null, { secret, options })).should.throw(typeIntegerError);
 		});
 
 		it('should throw an error if provided type is not an integer', () => {
 			options.type = 'not an integer';
-			(createDapp.bind(null, secret, null, options)).should.throw(typeIntegerError);
+			(createDapp.bind(null, { secret, options })).should.throw(typeIntegerError);
 		});
 
 		it('should throw an error if no link is provided', () => {
 			delete options.link;
-			(createDapp.bind(null, secret, null, options)).should.throw(linkStringError);
+			(createDapp.bind(null, { secret, options })).should.throw(linkStringError);
 		});
 
 		it('should throw an error if provided link is not a string', () => {
 			options.link = 123;
-			(createDapp.bind(null, secret, null, options)).should.throw(linkStringError);
+			(createDapp.bind(null, { secret, options })).should.throw(linkStringError);
 		});
 
 		it('should not require description, tags, or icon', () => {
 			['description', 'tags', 'icon'].forEach(key => delete options[key]);
-			(createDapp.bind(null, secret, null, options)).should.not.throw();
+			(createDapp.bind(null, { secret, options })).should.not.throw();
 		});
 
 		it('should use slots.getTimeWithOffset to calculate the timestamp', () => {
@@ -113,7 +113,7 @@ describe('#createDapp transaction', () => {
 
 		it('should use slots.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
 			const offset = -10;
-			createDapp(secret, null, options, offset);
+			createDapp({ secret, options, timeOffset: offset });
 
 			(getTimeWithOffsetStub.calledWithExactly(offset)).should.be.true();
 		});
@@ -208,11 +208,11 @@ describe('#createDapp transaction', () => {
 
 	describe('with second secret', () => {
 		beforeEach(() => {
-			createDappTransaction = createDapp(secret, secondSecret, options);
+			createDappTransaction = createDapp({ secret, secondSecret, options });
 		});
 
 		it('should create a create dapp transaction with a second secret', () => {
-			const createDappTransactionWithoutSecondSecret = createDapp(secret, null, options);
+			const createDappTransactionWithoutSecondSecret = createDapp({ secret, options });
 			(createDappTransaction).should.be.ok();
 			(createDappTransaction).should.not.be.equal(createDappTransactionWithoutSecondSecret);
 		});

--- a/test/transactions/6_transferIntoDapp.js
+++ b/test/transactions/6_transferIntoDapp.js
@@ -38,7 +38,7 @@ describe('#transferIntoDapp transaction', () => {
 
 	describe('with one secret', () => {
 		beforeEach(() => {
-			transferIntoDappTransaction = transferIntoDapp(dappId, amount, secret);
+			transferIntoDappTransaction = transferIntoDapp({ dappId, amount, secret });
 		});
 
 		it('should create an inTransfer dapp transaction', () => {
@@ -50,7 +50,7 @@ describe('#transferIntoDapp transaction', () => {
 		});
 
 		it('should use time slots with an offset of -10 seconds to get the time for the timestamp', () => {
-			transferIntoDapp(dappId, amount, secret, null, offset);
+			transferIntoDapp({ dappId, amount, secret, timeOffset: offset });
 
 			(getTimeWithOffsetStub.calledWithExactly(offset)).should.be.true();
 		});
@@ -120,15 +120,15 @@ describe('#transferIntoDapp transaction', () => {
 
 	describe('with second secret', () => {
 		beforeEach(() => {
-			transferIntoDappTransaction = transferIntoDapp(dappId, amount, secret, secondSecret);
+			transferIntoDappTransaction = transferIntoDapp({ dappId, amount, secret, secondSecret });
 		});
 
 		it('should create an transfer into dapp transaction with a second secret', () => {
-			const transferIntoDappTransactionWithoutSecondSecret = transferIntoDapp(
+			const transferIntoDappTransactionWithoutSecondSecret = transferIntoDapp({
 				dappId,
 				amount,
 				secret,
-			);
+			});
 			(transferIntoDappTransaction).should.be.ok();
 			(transferIntoDappTransaction).should.not.be.equal(
 				transferIntoDappTransactionWithoutSecondSecret,

--- a/test/transactions/7_transferOutOfDapp.js
+++ b/test/transactions/7_transferOutOfDapp.js
@@ -40,9 +40,9 @@ describe('#transferOutOfDapp', () => {
 
 	describe('with one secret', () => {
 		beforeEach(() => {
-			transferOutOfDappTransaction = transferOutOfDapp(
+			transferOutOfDappTransaction = transferOutOfDapp({
 				dappId, transactionId, recipientId, amount, secret,
-			);
+			});
 		});
 
 		it('should create an out transfer dapp transaction', () => {
@@ -54,7 +54,7 @@ describe('#transferOutOfDapp', () => {
 		});
 
 		it('should use time slots with an offset of -10 seconds to get the time for the timestamp', () => {
-			transferOutOfDapp(dappId, transactionId, recipientId, amount, secret, null, offset);
+			transferOutOfDapp({ dappId, transactionId, recipientId, amount, secret, timeOffset: offset });
 
 			(getTimeWithOffsetStub.calledWithExactly(offset)).should.be.true();
 		});
@@ -130,15 +130,15 @@ describe('#transferOutOfDapp', () => {
 
 		describe('with second secret', () => {
 			beforeEach(() => {
-				transferOutOfDappTransaction = transferOutOfDapp(
+				transferOutOfDappTransaction = transferOutOfDapp({
 					dappId, transactionId, recipientId, amount, secret, secondSecret,
-				);
+				});
 			});
 
 			it('should create a transfer out of dapp transaction with a second secret', () => {
-				const transferOutOfDappTransactionWithoutSecondSecret = transferOutOfDapp(
+				const transferOutOfDappTransactionWithoutSecondSecret = transferOutOfDapp({
 					dappId, transactionId, recipientId, amount, secret,
-				);
+				});
 				(transferOutOfDappTransaction).should.be.ok();
 				(transferOutOfDappTransaction).should.not.be.equal(
 					transferOutOfDappTransactionWithoutSecondSecret,


### PR DESCRIPTION
Use single option parameter as an argument for functions in these `transaction` modules:
- [x] `send`
- [x] `sendFromMultisignatureAccount`
- [x] `registerSecondSignature`
- [x] `registerDelegate`
- [x] `castVotes`
- [x] `registerMultisignatureAccount`
- [x] `createDapp`
- [x] `ransferIntoDapp`
- [x] `transferOutOfDapp`

close #337 