### PR TITLE
:recycle: Move getTransactionHash into transactions module - Closes #401

### DIFF
--- a/src/crypto/convert.js
+++ b/src/crypto/convert.js
@@ -14,7 +14,7 @@
  */
 import bignum from 'browserify-bignum';
 import ed2curve from 'ed2curve';
-import { getSha256Hash } from './hash';
+import hash from './hash';
 import { getTransactionBytes } from '../transactions/utils';
 
 /**
@@ -71,7 +71,7 @@ export function toAddress(buffer) {
  */
 
 export function getAddressFromPublicKey(publicKey) {
-	const publicKeyHash = getSha256Hash(publicKey, 'hex');
+	const publicKeyHash = hash(publicKey, 'hex');
 
 	const publicKeyTransform = getFirstEightBytesReversed(publicKeyHash);
 	const address = toAddress(publicKeyTransform);
@@ -99,7 +99,7 @@ export function getAddress(publicKey) {
 
 export function getId(transaction) {
 	const transactionBytes = getTransactionBytes(transaction);
-	const transactionHash = getSha256Hash(transactionBytes);
+	const transactionHash = hash(transactionBytes);
 	const bufferFromFirstEntriesReversed = getFirstEightBytesReversed(
 		transactionHash,
 	);

--- a/src/crypto/hash.js
+++ b/src/crypto/hash.js
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { getTransactionBytes } from '../transactions/utils';
 
 /**
  * @method getSha256Hash
@@ -21,6 +20,7 @@ import { getTransactionBytes } from '../transactions/utils';
  *
  * @return {string}
  */
+// eslint-disable-next-line import/prefer-default-export
 export function getSha256Hash(data, format) {
 	if (Buffer.isBuffer(data)) {
 		return Buffer.from(naclInstance.crypto_hash_sha256(data));
@@ -42,16 +42,4 @@ export function getSha256Hash(data, format) {
 	throw new Error(
 		'Unsupported data format. Currently only Buffers or `hex` and `utf8` strings are supported.',
 	);
-}
-
-/**
- * @method getTransactionHash
- * @param transaction Object
- *
- * @return {string}
- */
-
-export function getTransactionHash(transaction) {
-	const bytes = getTransactionBytes(transaction);
-	return getSha256Hash(bytes);
 }

--- a/src/crypto/hash.js
+++ b/src/crypto/hash.js
@@ -14,14 +14,14 @@
  */
 
 /**
- * @method getSha256Hash
+ * @method hash
  * @param data
  * @param format
  *
  * @return {string}
  */
-// eslint-disable-next-line import/prefer-default-export
-export function getSha256Hash(data, format) {
+
+export default function hash(data, format) {
 	if (Buffer.isBuffer(data)) {
 		return Buffer.from(naclInstance.crypto_hash_sha256(data));
 	}

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -13,8 +13,8 @@
  *
  */
 import * as convert from './convert';
-import * as hash from './hash';
+import hash from './hash';
 import * as keys from './keys';
 import * as sign from './sign';
 
-export default Object.assign({}, convert, hash, keys, sign);
+export default Object.assign({}, convert, { hash }, keys, sign);

--- a/src/crypto/keys.js
+++ b/src/crypto/keys.js
@@ -13,7 +13,7 @@
  *
  */
 import { bufferToHex, getAddress } from './convert';
-import { getSha256Hash } from './hash';
+import hash from './hash';
 
 /**
  * @method getRawPrivateAndPublicKeyFromSecret
@@ -23,9 +23,9 @@ import { getSha256Hash } from './hash';
  */
 
 export function getRawPrivateAndPublicKeyFromSecret(secret) {
-	const sha256Hash = getSha256Hash(secret, 'utf8');
+	const hashed = hash(secret, 'utf8');
 
-	const { signSk, signPk } = naclInstance.crypto_sign_seed_keypair(sha256Hash);
+	const { signSk, signPk } = naclInstance.crypto_sign_seed_keypair(hashed);
 
 	return {
 		privateKey: signSk,

--- a/src/crypto/sign.js
+++ b/src/crypto/sign.js
@@ -19,7 +19,7 @@ import {
 	convertPrivateKeyEd2Curve,
 	convertPublicKeyEd2Curve,
 } from './convert';
-import { getSha256Hash } from './hash';
+import hash from './hash';
 import { getTransactionHash } from '../transactions/utils';
 import { getRawPrivateAndPublicKeyFromSecret } from './keys';
 
@@ -383,7 +383,7 @@ export function decryptMessageWithSecret(
 
 function encryptAES256CBCWithPassword(plainText, password) {
 	const iv = crypto.randomBytes(16);
-	const passwordHash = getSha256Hash(password, 'utf8');
+	const passwordHash = hash(password, 'utf8');
 	const cipher = crypto.createCipheriv('aes-256-cbc', passwordHash, iv);
 	const firstBlock = cipher.update(plainText, 'utf8');
 	const encrypted = Buffer.concat([firstBlock, cipher.final()]);
@@ -405,7 +405,7 @@ function encryptAES256CBCWithPassword(plainText, password) {
  */
 
 function decryptAES256CBCWithPassword({ cipher, iv }, password) {
-	const passwordHash = getSha256Hash(password, 'utf8');
+	const passwordHash = hash(password, 'utf8');
 	const decipherInit = crypto.createDecipheriv(
 		'aes-256-cbc',
 		passwordHash,

--- a/src/crypto/sign.js
+++ b/src/crypto/sign.js
@@ -19,7 +19,8 @@ import {
 	convertPrivateKeyEd2Curve,
 	convertPublicKeyEd2Curve,
 } from './convert';
-import { getTransactionHash, getSha256Hash } from './hash';
+import { getSha256Hash } from './hash';
+import { getTransactionHash } from '../transactions/utils';
 import { getRawPrivateAndPublicKeyFromSecret } from './keys';
 
 const createHeader = text => `-----${text}-----`;

--- a/src/transactions/utils/getTransactionHash.js
+++ b/src/transactions/utils/getTransactionHash.js
@@ -12,7 +12,17 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { default as getTransactionBytes } from './getTransactionBytes';
-export { default as getTransactionHash } from './getTransactionHash';
-export { default as prepareTransaction } from './prepareTransaction';
-export { getTimeFromBlockchainEpoch, getTimeWithOffset } from './time';
+import crypto from '../../crypto';
+import getTransactionBytes from './getTransactionBytes';
+
+/**
+* @method getTransactionHash
+* @param transaction Object
+*
+* @return {string}
+*/
+
+export default function getTransactionHash(transaction) {
+	const bytes = getTransactionBytes(transaction);
+	return crypto.getSha256Hash(bytes);
+}

--- a/src/transactions/utils/getTransactionHash.js
+++ b/src/transactions/utils/getTransactionHash.js
@@ -24,5 +24,5 @@ import getTransactionBytes from './getTransactionBytes';
 
 export default function getTransactionHash(transaction) {
 	const bytes = getTransactionBytes(transaction);
-	return crypto.getSha256Hash(bytes);
+	return crypto.hash(bytes);
 }

--- a/test/crypto/convert.js
+++ b/test/crypto/convert.js
@@ -106,7 +106,7 @@ describe('convert', () => {
 
 	describe('#getAddressFromPublicKey', () => {
 		beforeEach(() => {
-			sandbox.stub(hash, 'getSha256Hash').returns(defaultPublicKeyHash);
+			sandbox.stub(hash, 'default').returns(defaultPublicKeyHash);
 		});
 
 		it('should generate address from publicKey', () => {
@@ -117,7 +117,7 @@ describe('convert', () => {
 
 	describe('#getAddress', () => {
 		beforeEach(() => {
-			sandbox.stub(hash, 'getSha256Hash').returns(defaultPublicKeyHash);
+			sandbox.stub(hash, 'default').returns(defaultPublicKeyHash);
 		});
 
 		it('should generate address from publicKey', () => {
@@ -128,7 +128,7 @@ describe('convert', () => {
 
 	describe('#getId', () => {
 		beforeEach(() => {
-			sandbox.stub(hash, 'getSha256Hash').returns(defaultTransactionHash);
+			sandbox.stub(hash, 'default').returns(defaultTransactionHash);
 			sandbox.stub(utils, 'getTransactionBytes');
 		});
 

--- a/test/crypto/hash.js
+++ b/test/crypto/hash.js
@@ -12,53 +12,51 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { getSha256Hash } from '../../src/crypto/hash';
+import hashFunction from '../../src/crypto/hash';
 
 describe('hash', () => {
-	describe('#getSha256Hash', () => {
-		const defaultText = 'text123*';
-		let arrayToHash;
-		let defaultHash;
+	const defaultText = 'text123*';
+	let arrayToHash;
+	let defaultHash;
 
-		beforeEach(() => {
-			defaultHash = Buffer.from(
-				'7607d6792843d6003c12495b54e34517a508d2a8622526aff1884422c5478971',
-				'hex',
+	beforeEach(() => {
+		defaultHash = Buffer.from(
+			'7607d6792843d6003c12495b54e34517a508d2a8622526aff1884422c5478971',
+			'hex',
+		);
+		arrayToHash = [1, 2, 3];
+	});
+
+	it('should generate a sha256 hash from a Buffer', () => {
+		const testBuffer = Buffer.from(defaultText);
+		const hash = hashFunction(testBuffer);
+		hash.should.be.eql(defaultHash);
+	});
+
+	it('should generate a sha256 hash from a utf8 string', () => {
+		const hash = hashFunction(defaultText, 'utf8');
+		hash.should.be.eql(defaultHash);
+	});
+
+	it('should generate a sha256 hash from a hex string', () => {
+		const testHex = Buffer.from(defaultText).toString('hex');
+		const hash = hashFunction(testHex, 'hex');
+		hash.should.be.eql(defaultHash);
+	});
+
+	it('should throw on unknown format when trying a string with format "utf32"', () => {
+		hashFunction
+			.bind(null, defaultText, 'utf32')
+			.should.throw(
+				'Unsupported string format. Currently only `hex` and `utf8` are supported.',
 			);
-			arrayToHash = [1, 2, 3];
-		});
+	});
 
-		it('should generate a sha256 hash from a Buffer', () => {
-			const testBuffer = Buffer.from(defaultText);
-			const hash = getSha256Hash(testBuffer);
-			hash.should.be.eql(defaultHash);
-		});
-
-		it('should generate a sha256 hash from a utf8 string', () => {
-			const hash = getSha256Hash(defaultText, 'utf8');
-			hash.should.be.eql(defaultHash);
-		});
-
-		it('should generate a sha256 hash from a hex string', () => {
-			const testHex = Buffer.from(defaultText).toString('hex');
-			const hash = getSha256Hash(testHex, 'hex');
-			hash.should.be.eql(defaultHash);
-		});
-
-		it('should throw on unknown format when trying a string with format "utf32"', () => {
-			getSha256Hash
-				.bind(null, defaultText, 'utf32')
-				.should.throw(
-					'Unsupported string format. Currently only `hex` and `utf8` are supported.',
-				);
-		});
-
-		it('should throw on unknown format when using an array', () => {
-			getSha256Hash
-				.bind(null, arrayToHash)
-				.should.throw(
-					'Unsupported data format. Currently only Buffers or `hex` and `utf8` strings are supported.',
-				);
-		});
+	it('should throw on unknown format when using an array', () => {
+		hashFunction
+			.bind(null, arrayToHash)
+			.should.throw(
+				'Unsupported data format. Currently only Buffers or `hex` and `utf8` strings are supported.',
+			);
 	});
 });

--- a/test/crypto/hash.js
+++ b/test/crypto/hash.js
@@ -12,9 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { getSha256Hash, getTransactionHash } from '../../src/crypto/hash';
-
-const getTransactionBytes = require('../../src/transactions/utils/getTransactionBytes');
+import { getSha256Hash } from '../../src/crypto/hash';
 
 describe('hash', () => {
 	describe('#getSha256Hash', () => {
@@ -61,48 +59,6 @@ describe('hash', () => {
 				.should.throw(
 					'Unsupported data format. Currently only Buffers or `hex` and `utf8` strings are supported.',
 				);
-		});
-	});
-
-	describe('#getTransactionHash', () => {
-		let defaultTransactionBytes;
-		let transactionBytesStub;
-		let transaction;
-		let result;
-
-		beforeEach(() => {
-			defaultTransactionBytes = Buffer.from(
-				'00aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153de803000000000000618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
-				'hex',
-			);
-			transactionBytesStub = sandbox
-				.stub(getTransactionBytes, 'default')
-				.returns(defaultTransactionBytes);
-			transaction = {
-				type: 0,
-				amount: 1000,
-				recipientId: '58191285901858109L',
-				timestamp: 141738,
-				asset: {},
-				senderPublicKey:
-					'5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09',
-				signature:
-					'618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
-				id: '13987348420913138422',
-			};
-			result = getTransactionHash(transaction);
-		});
-
-		it('should get transaction bytes', () => {
-			transactionBytesStub.calledWithExactly(transaction).should.be.true();
-		});
-
-		it('should return a hash for a transaction object as a Buffer', () => {
-			const expected = Buffer.from(
-				'f60a26da470b1dc233fd526ed7306c1d84836f9e2ecee82c9ec47319e0910474',
-				'hex',
-			);
-			result.should.be.eql(expected);
 		});
 	});
 });

--- a/test/crypto/keys.js
+++ b/test/crypto/keys.js
@@ -46,7 +46,7 @@ describe('keys', () => {
 			.withArgs(Buffer.from(defaultPublicKey, 'hex'))
 			.returns(defaultPublicKey);
 		sandbox
-			.stub(hash, 'getSha256Hash')
+			.stub(hash, 'default')
 			.returns(Buffer.from(defaultSecretHash, 'hex'));
 	});
 

--- a/test/crypto/sign.js
+++ b/test/crypto/sign.js
@@ -92,7 +92,7 @@ ${defaultSecondSignature}
 
 	let getRawPrivateAndPublicKeyFromSecretStub;
 	let getTransactionHashStub;
-	let getSha256HashStub;
+	let hashStub;
 
 	beforeEach(() => {
 		defaultSignedMessage = {
@@ -161,8 +161,8 @@ ${defaultSecondSignature}
 					'hex',
 				),
 			);
-		getSha256HashStub = sandbox
-			.stub(hash, 'getSha256Hash')
+		hashStub = sandbox
+			.stub(hash, 'default')
 			.returns(
 				Buffer.from(
 					'd43eed9049dd8f35106c720669a1148b2c6288d9ea517b936c33a1d84117a760',
@@ -551,7 +551,7 @@ ${defaultSecondSignature}
 
 	describe('encrypt and decrypt passphrase with password', () => {
 		beforeEach(() => {
-			getSha256HashStub.returns(
+			hashStub.returns(
 				Buffer.from(
 					'e09dfc943d65d63f4f31e444c81afc6d5cf442c988fb87180165dd7119d3ae61',
 					'hex',

--- a/test/crypto/sign.js
+++ b/test/crypto/sign.js
@@ -31,6 +31,7 @@ import {
 const convert = require('../../src/crypto/convert');
 const keys = require('../../src/crypto/keys');
 const hash = require('../../src/crypto/hash');
+const getTransactionHash = require('../../src/transactions/utils/getTransactionHash');
 
 const makeInvalid = str => {
 	const char = str[0] === '0' ? '1' : '0';
@@ -153,7 +154,7 @@ ${defaultSecondSignature}
 			});
 
 		getTransactionHashStub = sandbox
-			.stub(hash, 'getTransactionHash')
+			.stub(getTransactionHash, 'default')
 			.returns(
 				Buffer.from(
 					'c62214460d66eeb1d9db3fb708e31040d2629fbdb6c93887c5eb0f3243912f91',

--- a/test/transactions/utils/getTransactionHash.js
+++ b/test/transactions/utils/getTransactionHash.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { getTransactionHash } from '../../../src/transactions/utils';
+
+const getTransactionBytes = require('../../../src/transactions/utils/getTransactionBytes');
+
+describe('#getTransactionHash', () => {
+	let defaultTransactionBytes;
+	let transactionBytesStub;
+	let transaction;
+	let result;
+
+	beforeEach(() => {
+		defaultTransactionBytes = Buffer.from(
+			'00aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153de803000000000000618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
+			'hex',
+		);
+		transactionBytesStub = sandbox
+			.stub(getTransactionBytes, 'default')
+			.returns(defaultTransactionBytes);
+		transaction = {
+			type: 0,
+			amount: 1000,
+			recipientId: '58191285901858109L',
+			timestamp: 141738,
+			asset: {},
+			senderPublicKey:
+				'5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09',
+			signature:
+				'618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
+			id: '13987348420913138422',
+		};
+		result = getTransactionHash(transaction);
+	});
+
+	it('should get transaction bytes', () => {
+		transactionBytesStub.calledWithExactly(transaction).should.be.true();
+	});
+
+	it('should return a hash for a transaction object as a Buffer', () => {
+		const expected = Buffer.from(
+			'f60a26da470b1dc233fd526ed7306c1d84836f9e2ecee82c9ec47319e0910474',
+			'hex',
+		);
+		result.should.be.eql(expected);
+	});
+});

--- a/test/transactions/utils/index.js
+++ b/test/transactions/utils/index.js
@@ -16,6 +16,7 @@ import {
 	getTimeFromBlockchainEpoch,
 	getTimeWithOffset,
 	getTransactionBytes,
+	getTransactionHash,
 	prepareTransaction,
 } from '../../../src/transactions/utils';
 
@@ -31,6 +32,10 @@ describe('transaction utils', () => {
 
 		it('should have getTransactionBytes', () => {
 			getTransactionBytes.should.be.type('function');
+		});
+
+		it('should have getTransactionBytes', () => {
+			getTransactionHash.should.be.type('function');
 		});
 
 		it('should have prepareTransaction', () => {


### PR DESCRIPTION
Closes #401 
In `src/crypto/hash.js` I disabled an eslint rule for preferring default exports thinking we might want more hash functions in future, but an alternative would be to make `getSha256Hash` the default export instead.