### PR TITLE
Add node build check - Closes #466

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
 			steps {
 				sh '''
 				npm run build
+				npm run build:check
 				npm run build:browsertest
 				HTTP_PORT=808${EXECUTOR_NUMBER:-0}
 				npm run serve:browsertest -- -p $HTTP_PORT >access.log 2>&1 &

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"serve:browsertest": "http-server browsertest",
 		"jenkins": "grunt jenkins --verbose",
 		"build": "grunt build",
+		"build:check": "node -e \"require('./dist-node')\"",
 		"build:browsertest": "grunt build-browsertest",
 		"precommit": "lint-staged && npm run eslint",
 		"prepush": "npm run eslint && npm test",


### PR DESCRIPTION
Closes #466

This just adds a basic check to see if requiring the build distribution for node errors. In the issue it suggested running the full test suite against the built files, so we might need to discuss this before merging.