### PR TITLE
Add multiple node.js version support - Closes #561

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,16 @@
 			"integrity": "sha512-Ey34vw8L2L1tFBLAsjCYlv24TVjzuU+sCUwONj8xMdlM5iNEHgj+AoMPR6C1LCijm/9Ue/FNAMffDe/lmKYWTA==",
 			"dev": true
 		},
+		"JSONStream": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+			"integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+			"dev": true,
+			"requires": {
+				"jsonparse": "1.3.1",
+				"through": "2.3.8"
+			}
+		},
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1028,9 +1038,9 @@
 			"integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
 			"dev": true,
 			"requires": {
+				"JSONStream": "1.3.1",
 				"combine-source-map": "0.7.2",
 				"defined": "1.0.0",
-				"JSONStream": "1.3.1",
 				"through2": "2.0.3",
 				"umd": "3.0.1"
 			}
@@ -1064,6 +1074,7 @@
 			"integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
 			"dev": true,
 			"requires": {
+				"JSONStream": "1.3.1",
 				"assert": "1.4.1",
 				"browser-pack": "6.0.2",
 				"browser-resolve": "1.11.2",
@@ -1085,7 +1096,6 @@
 				"https-browserify": "0.0.1",
 				"inherits": "2.0.3",
 				"insert-module-globals": "7.0.1",
-				"JSONStream": "1.3.1",
 				"labeled-stream-splicer": "2.0.0",
 				"module-deps": "4.1.1",
 				"os-browserify": "0.1.2",
@@ -3542,14 +3552,6 @@
 						}
 					}
 				},
-				"string_decoder": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
@@ -3558,6 +3560,14 @@
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
 						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
 					}
 				},
 				"stringstream": {
@@ -4460,10 +4470,10 @@
 			"integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
 			"dev": true,
 			"requires": {
+				"JSONStream": "1.3.1",
 				"combine-source-map": "0.7.2",
 				"concat-stream": "1.5.2",
 				"is-buffer": "1.1.6",
-				"JSONStream": "1.3.1",
 				"lexical-scope": "1.2.0",
 				"process": "0.11.10",
 				"through2": "2.0.3",
@@ -4934,16 +4944,6 @@
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
 			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
 			"dev": true
-		},
-		"JSONStream": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-			"integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-			"dev": true,
-			"requires": {
-				"jsonparse": "1.3.1",
-				"through": "2.3.8"
-			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -5614,6 +5614,7 @@
 			"integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
 			"dev": true,
 			"requires": {
+				"JSONStream": "1.3.1",
 				"browser-resolve": "1.11.2",
 				"cached-path-relative": "1.0.1",
 				"concat-stream": "1.5.2",
@@ -5621,7 +5622,6 @@
 				"detective": "4.5.0",
 				"duplexer2": "0.1.4",
 				"inherits": "2.0.3",
-				"JSONStream": "1.3.1",
 				"parents": "1.0.1",
 				"readable-stream": "2.3.3",
 				"resolve": "1.5.0",
@@ -5777,7 +5777,7 @@
 		"nyc": {
 			"version": "11.3.0",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.3.0.tgz",
-			"integrity": "sha1-pCvBezz6QfexXrYCvJiyYz3ddvA=",
+			"integrity": "sha512-oUu0WHt1k/JMIODvAYXX6C50Mupw2GO34P/Jdg2ty9xrLufBthHiKR2gf08aF+9S0abW1fl24R7iKRBXzibZmg==",
 			"dev": true,
 			"requires": {
 				"archy": "1.0.0",
@@ -8654,14 +8654,6 @@
 			"integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
 			"dev": true
 		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
-		},
 		"string-width": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8671,6 +8663,14 @@
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
 				"strip-ansi": "3.0.1"
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"stringify-object": {
@@ -9186,6 +9186,7 @@
 					"integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
 					"dev": true,
 					"requires": {
+						"JSONStream": "1.3.1",
 						"assert": "1.4.1",
 						"browser-pack": "6.0.2",
 						"browser-resolve": "1.11.2",
@@ -9207,7 +9208,6 @@
 						"https-browserify": "1.0.0",
 						"inherits": "2.0.3",
 						"insert-module-globals": "7.0.1",
-						"JSONStream": "1.3.1",
 						"labeled-stream-splicer": "2.0.0",
 						"module-deps": "4.1.1",
 						"os-browserify": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -356,6 +356,20 @@
 			"integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
 			"dev": true
 		},
+		"babel-plugin-module-resolver": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.0.0.tgz",
+			"integrity": "sha512-U394VtqR+uGozwV43paA9tUOJ2WYP/OpLMla7u/Qi+/A0chDwuRoYu1hkqkkNTAvoq21ybSIgdCeDV4GVvqfeA==",
+			"dev": true,
+			"dependencies": {
+				"pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+					"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+					"dev": true
+				}
+			}
+		},
 		"babel-plugin-rewire": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-rewire/-/babel-plugin-rewire-1.1.0.tgz",
@@ -1758,6 +1772,12 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true
+		},
+		"find-babel-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.1.0.tgz",
+			"integrity": "sha1-rMAQQ6Z0n+w0Qpvmtk9ULrtdY1U=",
 			"dev": true
 		},
 		"find-up": {
@@ -6038,6 +6058,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
+		},
+		"reselect": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+			"integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=",
 			"dev": true
 		},
 		"resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,35 +2,32 @@
 	"name": "lisk-js",
 	"version": "0.4.5",
 	"lockfileVersion": 1,
-	"requires": true,
 	"dependencies": {
+		"@browserify/acorn5-object-spread": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@browserify/acorn5-object-spread/-/acorn5-object-spread-5.0.1.tgz",
+			"integrity": "sha512-sFCUPzgeEjdq3rinwy4TFXtak2YZdhqpj6MdNusxkdTFr9TXAUEYK4YQSamR8Joqt/yii1drgl5hk8q/AtJDKA==",
+			"dev": true,
+			"dependencies": {
+				"acorn": {
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+					"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+					"dev": true
+				}
+			}
+		},
 		"@cypress/listr-verbose-renderer": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
 			"integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"date-fns": "1.29.0",
-				"figures": "1.7.0"
-			}
+			"dev": true
 		},
 		"@cypress/xvfb": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.0.4.tgz",
 			"integrity": "sha512-Ey34vw8L2L1tFBLAsjCYlv24TVjzuU+sCUwONj8xMdlM5iNEHgj+AoMPR6C1LCijm/9Ue/FNAMffDe/lmKYWTA==",
 			"dev": true
-		},
-		"JSONStream": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-			"integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-			"dev": true,
-			"requires": {
-				"jsonparse": "1.3.1",
-				"through": "2.3.8"
-			}
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -49,9 +46,6 @@
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
-			"requires": {
-				"acorn": "3.3.0"
-			},
 			"dependencies": {
 				"acorn": {
 					"version": "3.3.0",
@@ -61,15 +55,25 @@
 				}
 			}
 		},
+		"acorn-node": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.3.0.tgz",
+			"integrity": "sha512-efP54n3d1aLfjL2UMdaXa6DsswwzJeI5rqhbFvXMrKiJ6eJFpf+7R0zN7t8IC+XKn2YOAFAv6xbBNgHUkoHWLw==",
+			"dev": true,
+			"dependencies": {
+				"acorn": {
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+					"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+					"dev": true
+				}
+			}
+		},
 		"ajv": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-			"dev": true,
-			"requires": {
-				"co": "4.6.0",
-				"json-stable-stringify": "1.0.1"
-			}
+			"dev": true
 		},
 		"ajv-keywords": {
 			"version": "2.1.1",
@@ -99,11 +103,7 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-			"dev": true,
-			"requires": {
-				"micromatch": "2.3.11",
-				"normalize-path": "2.1.1"
-			}
+			"dev": true
 		},
 		"app-root-path": {
 			"version": "2.0.1",
@@ -112,22 +112,16 @@
 			"dev": true
 		},
 		"argparse": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-			"dev": true,
-			"requires": {
-				"sprintf-js": "1.0.3"
-			}
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true
 		},
 		"arr-diff": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"dev": true,
-			"requires": {
-				"arr-flatten": "1.1.0"
-			}
+			"dev": true
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
@@ -169,10 +163,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"dev": true,
-			"requires": {
-				"array-uniq": "1.0.3"
-			}
+			"dev": true
 		},
 		"array-uniq": {
 			"version": "1.0.3",
@@ -199,24 +190,16 @@
 			"dev": true
 		},
 		"asn1.js": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
-			"dev": true,
-			"requires": {
-				"bn.js": "4.11.8",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
-			}
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"dev": true
 		},
 		"assert": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
 			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-			"dev": true,
-			"requires": {
-				"util": "0.10.3"
-			}
+			"dev": true
 		},
 		"assert-plus": {
 			"version": "0.2.0",
@@ -228,19 +211,13 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
 			"integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
-			"dev": true,
-			"requires": {
-				"acorn": "4.0.13"
-			}
+			"dev": true
 		},
 		"async": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
 			"integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
-			"dev": true,
-			"requires": {
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.1",
@@ -269,244 +246,115 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
 			"integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
-			"dev": true,
-			"requires": {
-				"babel-core": "6.26.0",
-				"babel-polyfill": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"chokidar": "1.7.0",
-				"commander": "2.11.0",
-				"convert-source-map": "1.5.0",
-				"fs-readdir-recursive": "1.1.0",
-				"glob": "7.1.2",
-				"lodash": "4.17.4",
-				"output-file-sync": "1.1.2",
-				"path-is-absolute": "1.0.1",
-				"slash": "1.0.0",
-				"source-map": "0.5.7",
-				"v8flags": "2.1.1"
-			}
+			"dev": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
-			}
+			"dev": true
 		},
 		"babel-core": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-generator": "6.26.0",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"convert-source-map": "1.5.0",
-				"debug": "2.6.9",
-				"json5": "0.5.1",
-				"lodash": "4.17.4",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.8",
-				"slash": "1.0.0",
-				"source-map": "0.5.7"
-			}
+			"dev": true
 		},
 		"babel-generator": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-			"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-			"dev": true,
-			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.4",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
-			}
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"dev": true,
-			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-helper-call-delegate": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"dev": true,
-			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-helper-define-map": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-			"dev": true,
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"babel-helper-explode-assignable-expression": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-helper-function-name": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"dev": true,
-			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-helper-get-function-arity": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-helper-hoist-variables": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-helper-optimise-call-expression": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-helper-regex": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"babel-helper-remap-async-to-generator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"dev": true,
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-helper-replace-supers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-			"dev": true,
-			"requires": {
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-helpers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-messages": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-check-es2015-constants": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-istanbul": {
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
 			"integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
-			"dev": true,
-			"requires": {
-				"find-up": "2.1.0",
-				"istanbul-lib-instrument": "1.9.1",
-				"test-exclude": "4.1.1"
-			}
+			"dev": true
 		},
 		"babel-plugin-rewire": {
 			"version": "1.1.0",
@@ -536,407 +384,212 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"dev": true,
-			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-classes": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-			"dev": true,
-			"requires": {
-				"babel-helper-define-map": "6.26.0",
-				"babel-helper-function-name": "6.24.1",
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-destructuring": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-for-of": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-function-name": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"dev": true,
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-literals": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-			"dev": true,
-			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-			"dev": true,
-			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"dev": true,
-			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"dev": true,
-			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-object-super": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"dev": true,
-			"requires": {
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-parameters": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"dev": true,
-			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-spread": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"dev": true,
-			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-template-literals": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"dev": true,
-			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"regexpu-core": "2.0.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-exponentiation-operator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"dev": true,
-			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-regenerator": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-			"dev": true,
-			"requires": {
-				"regenerator-transform": "0.10.1"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-runtime": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
 			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-strict-mode": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
+			"dev": true
 		},
 		"babel-polyfill": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-			"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
 			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.1",
-				"regenerator-runtime": "0.10.5"
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.10.5",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+					"dev": true
+				}
 			}
 		},
 		"babel-preset-env": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
 			"integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
-			"dev": true,
-			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0",
-				"browserslist": "2.9.0",
-				"invariant": "2.2.2",
-				"semver": "5.4.1"
-			}
+			"dev": true
 		},
 		"babel-register": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"dev": true,
-			"requires": {
-				"babel-core": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.1",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.4",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
-			}
+			"dev": true
 		},
 		"babel-runtime": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"requires": {
-				"core-js": "2.5.1",
-				"regenerator-runtime": "0.11.0"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-					"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
-				}
-			}
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4="
 		},
 		"babel-template": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"babel-traverse": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.2",
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"babel-types": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.4",
-				"to-fast-properties": "1.0.3"
-			}
+			"dev": true
 		},
 		"babylon": {
 			"version": "6.18.0",
@@ -961,28 +614,18 @@
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 			"dev": true,
-			"optional": true,
-			"requires": {
-				"tweetnacl": "0.14.5"
-			}
+			"optional": true
 		},
 		"binary-extensions": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-			"integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
 			"dev": true
 		},
 		"bip39": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/bip39/-/bip39-2.4.0.tgz",
-			"integrity": "sha512-1++HywqIyPtWDo7gm4v0ylYbwkLvHkuwVSKbBlZBbTCP/mnkyrlARBny906VLAwxJbC5xw9EvuJasHFIZaIFMQ==",
-			"requires": {
-				"create-hash": "1.1.3",
-				"pbkdf2": "3.0.14",
-				"randombytes": "2.0.5",
-				"safe-buffer": "5.1.1",
-				"unorm": "1.4.1"
-			}
+			"integrity": "sha512-1++HywqIyPtWDo7gm4v0ylYbwkLvHkuwVSKbBlZBbTCP/mnkyrlARBny906VLAwxJbC5xw9EvuJasHFIZaIFMQ=="
 		},
 		"bluebird": {
 			"version": "2.11.0",
@@ -1000,31 +643,19 @@
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-			"dev": true,
-			"requires": {
-				"hoek": "2.16.3"
-			}
+			"dev": true
 		},
 		"brace-expansion": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-			"dev": true,
-			"requires": {
-				"balanced-match": "1.0.0",
-				"concat-map": "0.0.1"
-			}
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true
 		},
 		"braces": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-			"dev": true,
-			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
-			}
+			"dev": true
 		},
 		"brorand": {
 			"version": "1.1.0",
@@ -1033,26 +664,16 @@
 			"dev": true
 		},
 		"browser-pack": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
-			"integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
-			"dev": true,
-			"requires": {
-				"JSONStream": "1.3.1",
-				"combine-source-map": "0.7.2",
-				"defined": "1.0.0",
-				"through2": "2.0.3",
-				"umd": "3.0.1"
-			}
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.4.tgz",
+			"integrity": "sha512-Q4Rvn7P6ObyWfc4stqLWHtG1MJ8vVtjgT24Zbu+8UTzxYuZouqZsmNRRTFVMY/Ux0eIKv1d+JWzsInTX+fdHPQ==",
+			"dev": true
 		},
 		"browser-resolve": {
 			"version": "1.11.2",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
 			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
 			"dev": true,
-			"requires": {
-				"resolve": "1.1.7"
-			},
 			"dependencies": {
 				"resolve": {
 					"version": "1.1.7",
@@ -1073,82 +694,26 @@
 			"resolved": "https://registry.npmjs.org/browserify/-/browserify-13.3.0.tgz",
 			"integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
 			"dev": true,
-			"requires": {
-				"JSONStream": "1.3.1",
-				"assert": "1.4.1",
-				"browser-pack": "6.0.2",
-				"browser-resolve": "1.11.2",
-				"browserify-zlib": "0.1.4",
-				"buffer": "4.9.1",
-				"cached-path-relative": "1.0.1",
-				"concat-stream": "1.5.2",
-				"console-browserify": "1.1.0",
-				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.12.0",
-				"defined": "1.0.0",
-				"deps-sort": "2.0.0",
-				"domain-browser": "1.1.7",
-				"duplexer2": "0.1.4",
-				"events": "1.1.1",
-				"glob": "7.1.2",
-				"has": "1.0.1",
-				"htmlescape": "1.1.1",
-				"https-browserify": "0.0.1",
-				"inherits": "2.0.3",
-				"insert-module-globals": "7.0.1",
-				"labeled-stream-splicer": "2.0.0",
-				"module-deps": "4.1.1",
-				"os-browserify": "0.1.2",
-				"parents": "1.0.1",
-				"path-browserify": "0.0.0",
-				"process": "0.11.10",
-				"punycode": "1.4.1",
-				"querystring-es3": "0.2.1",
-				"read-only-stream": "2.0.0",
-				"readable-stream": "2.3.3",
-				"resolve": "1.5.0",
-				"shasum": "1.0.2",
-				"shell-quote": "1.6.1",
-				"stream-browserify": "2.0.1",
-				"stream-http": "2.7.2",
-				"string_decoder": "0.10.31",
-				"subarg": "1.0.0",
-				"syntax-error": "1.3.0",
-				"through2": "2.0.3",
-				"timers-browserify": "1.4.2",
-				"tty-browserify": "0.0.0",
-				"url": "0.11.0",
-				"util": "0.10.3",
-				"vm-browserify": "0.0.4",
-				"xtend": "4.0.1"
-			},
 			"dependencies": {
 				"concat-stream": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
 					"integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
 					"dev": true,
-					"requires": {
-						"inherits": "2.0.3",
-						"readable-stream": "2.0.6",
-						"typedarray": "0.0.6"
-					},
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.0.6",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
 							"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-							"dev": true,
-							"requires": {
-								"core-util-is": "1.0.2",
-								"inherits": "2.0.3",
-								"isarray": "1.0.0",
-								"process-nextick-args": "1.0.7",
-								"string_decoder": "0.10.31",
-								"util-deprecate": "1.0.2"
-							}
+							"dev": true
 						}
 					}
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+					"dev": true
 				},
 				"string_decoder": {
 					"version": "0.10.31",
@@ -1162,15 +727,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
 			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
-			"dev": true,
-			"requires": {
-				"buffer-xor": "1.0.3",
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.3",
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
-			}
+			"dev": true
 		},
 		"browserify-bignum": {
 			"version": "1.3.0-2",
@@ -1181,78 +738,43 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
 			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-			"dev": true,
-			"requires": {
-				"browserify-aes": "1.1.1",
-				"browserify-des": "1.0.0",
-				"evp_bytestokey": "1.0.3"
-			}
+			"dev": true
 		},
 		"browserify-des": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
 			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-			"dev": true,
-			"requires": {
-				"cipher-base": "1.0.4",
-				"des.js": "1.0.0",
-				"inherits": "2.0.3"
-			}
+			"dev": true
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"dev": true,
-			"requires": {
-				"bn.js": "4.11.8",
-				"randombytes": "2.0.5"
-			}
+			"dev": true
 		},
 		"browserify-sign": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-			"dev": true,
-			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"elliptic": "6.4.0",
-				"inherits": "2.0.3",
-				"parse-asn1": "5.1.0"
-			}
+			"dev": true
 		},
 		"browserify-zlib": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
 			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-			"dev": true,
-			"requires": {
-				"pako": "0.2.9"
-			}
+			"dev": true
 		},
 		"browserslist": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.0.tgz",
-			"integrity": "sha512-vJEBcDTANoDhSHL46NeOEW5hvQw7It9uCqzeFPQhpawXfnOwnpvW5C97vn1eGJ7iCkSg8wWU0nYObE7d/N95Iw==",
-			"dev": true,
-			"requires": {
-				"caniuse-lite": "1.0.30000764",
-				"electron-to-chromium": "1.3.27"
-			}
+			"version": "2.11.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+			"dev": true
 		},
 		"buffer": {
 			"version": "4.9.1",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-			"dev": true,
-			"requires": {
-				"base64-js": "1.2.1",
-				"ieee754": "1.1.8",
-				"isarray": "1.0.0"
-			}
+			"dev": true
 		},
 		"buffer-crc32": {
 			"version": "0.2.13",
@@ -1288,10 +810,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-			"dev": true,
-			"requires": {
-				"callsites": "0.2.0"
-			}
+			"dev": true
 		},
 		"callsites": {
 			"version": "0.2.0",
@@ -1309,16 +828,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-			"dev": true,
-			"requires": {
-				"camelcase": "2.1.1",
-				"map-obj": "1.0.1"
-			}
+			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000764",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000764.tgz",
-			"integrity": "sha1-l+p0cvnT5pHu3jTyGYPPwhmseEI=",
+			"version": "1.0.30000808",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz",
+			"integrity": "sha512-vT0JLmHdvq1UVbYXioxCXHYdNw55tyvi+IUWyX0Zeh1OFQi2IllYtm38IJnSgHWCv/zUnX1hdhy3vMJvuTNSqw==",
 			"dev": true
 		},
 		"caseless": {
@@ -1331,45 +846,25 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
-			}
+			"dev": true
+		},
+		"chardet": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-			"dev": true,
-			"requires": {
-				"anymatch": "1.3.2",
-				"async-each": "1.0.1",
-				"fsevents": "1.1.3",
-				"glob-parent": "2.0.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "2.0.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
-			}
+			"dev": true
 		},
 		"chokidar-cli": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-1.2.0.tgz",
 			"integrity": "sha1-jn9YRCJzGCAYvhho5Twir2WiGUg=",
 			"dev": true,
-			"requires": {
-				"anymatch": "1.3.2",
-				"bluebird": "2.11.0",
-				"chokidar": "1.7.0",
-				"lodash": "3.10.1",
-				"shell-quote": "1.6.1",
-				"yargs": "3.32.0"
-			},
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
@@ -1380,19 +875,15 @@
 			}
 		},
 		"ci-info": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-			"integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+			"integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
 			"dev": true
 		},
 		"cipher-base": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
-			}
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q=="
 		},
 		"circular-json": {
 			"version": "0.3.3",
@@ -1404,10 +895,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-			"dev": true,
-			"requires": {
-				"restore-cursor": "1.0.1"
-			}
+			"dev": true
 		},
 		"cli-spinners": {
 			"version": "0.1.2",
@@ -1419,11 +907,7 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
 			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-			"dev": true,
-			"requires": {
-				"slice-ansi": "0.0.4",
-				"string-width": "1.0.2"
-			}
+			"dev": true
 		},
 		"cli-width": {
 			"version": "2.2.0",
@@ -1435,12 +919,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-			"dev": true,
-			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wrap-ansi": "2.1.0"
-			}
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
@@ -1464,10 +943,7 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.3"
-			}
+			"dev": true
 		},
 		"color-name": {
 			"version": "1.1.3",
@@ -1482,16 +958,10 @@
 			"dev": true
 		},
 		"combine-source-map": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
-			"integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+			"integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
 			"dev": true,
-			"requires": {
-				"convert-source-map": "1.1.3",
-				"inline-source-map": "0.6.2",
-				"lodash.memoize": "3.0.4",
-				"source-map": "0.5.7"
-			},
 			"dependencies": {
 				"convert-source-map": {
 					"version": "1.1.3",
@@ -1502,27 +972,21 @@
 			}
 		},
 		"combined-stream": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-			"requires": {
-				"delayed-stream": "1.0.0"
-			}
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg="
 		},
 		"commander": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
 			"dev": true
 		},
 		"common-tags": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
 			"integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1533,21 +997,13 @@
 		"concat-stream": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"typedarray": "0.0.6"
-			}
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc="
 		},
 		"console-browserify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-			"dev": true,
-			"requires": {
-				"date-now": "0.1.4"
-			}
+			"dev": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -1562,15 +1018,15 @@
 			"dev": true
 		},
 		"convert-source-map": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
 			"dev": true
 		},
 		"core-js": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-			"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1588,16 +1044,6 @@
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
 			"integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
 			"dev": true,
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"js-yaml": "3.6.1",
-				"minimist": "1.2.0",
-				"object-assign": "4.1.1",
-				"os-homedir": "1.0.2",
-				"parse-json": "2.2.0",
-				"pinkie-promise": "2.0.1",
-				"require-from-string": "1.2.1"
-			},
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
@@ -1612,13 +1058,6 @@
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
 			"integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
 			"dev": true,
-			"requires": {
-				"js-yaml": "3.6.1",
-				"lcov-parse": "0.0.10",
-				"log-driver": "1.2.5",
-				"minimist": "1.2.0",
-				"request": "2.79.0"
-			},
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
@@ -1632,123 +1071,53 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
 			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-			"dev": true,
-			"requires": {
-				"bn.js": "4.11.8",
-				"elliptic": "6.4.0"
-			}
+			"dev": true
 		},
 		"create-hash": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-			"requires": {
-				"cipher-base": "1.0.4",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"sha.js": "2.4.9"
-			}
+			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0="
 		},
 		"create-hmac": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
-			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-			"requires": {
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.9"
-			}
+			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY="
 		},
 		"cross-spawn": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
-			"requires": {
-				"lru-cache": "4.1.1",
-				"shebang-command": "1.2.0",
-				"which": "1.2.14"
-			}
+			"dev": true
 		},
 		"cryptiles": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-			"dev": true,
-			"requires": {
-				"boom": "2.10.1"
-			}
+			"dev": true
 		},
 		"crypto-browserify": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-			"dev": true,
-			"requires": {
-				"browserify-cipher": "1.0.0",
-				"browserify-sign": "4.0.4",
-				"create-ecdh": "4.0.0",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"diffie-hellman": "5.0.2",
-				"inherits": "2.0.3",
-				"pbkdf2": "3.0.14",
-				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5",
-				"randomfill": "1.0.3"
-			}
+			"dev": true
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"dev": true,
-			"requires": {
-				"array-find-index": "1.0.2"
-			}
+			"dev": true
 		},
 		"cypress": {
 			"version": "0.20.3",
 			"resolved": "https://registry.npmjs.org/cypress/-/cypress-0.20.3.tgz",
 			"integrity": "sha1-dBgWEkv+VEkXsi1UXNJmdpbAuxw=",
 			"dev": true,
-			"requires": {
-				"@cypress/listr-verbose-renderer": "0.4.1",
-				"@cypress/xvfb": "1.0.4",
-				"bluebird": "3.5.0",
-				"chalk": "2.1.0",
-				"commander": "2.9.0",
-				"common-tags": "1.4.0",
-				"debug": "2.6.8",
-				"extract-zip": "1.6.5",
-				"fs-extra": "4.0.1",
-				"getos": "2.8.4",
-				"glob": "7.1.2",
-				"is-ci": "1.0.10",
-				"is-installed-globally": "0.1.0",
-				"listr": "0.12.0",
-				"lodash": "4.17.4",
-				"minimist": "1.2.0",
-				"progress": "1.1.8",
-				"ramda": "0.24.1",
-				"request": "2.81.0",
-				"request-progress": "0.3.1",
-				"tmp": "0.0.31",
-				"url": "0.11.0",
-				"yauzl": "2.8.0"
-			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
-					"requires": {
-						"color-convert": "1.9.1"
-					}
+					"dev": true
 				},
 				"bluebird": {
 					"version": "3.5.0",
@@ -1766,51 +1135,37 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
 					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
-					}
+					"dev": true
 				},
 				"commander": {
 					"version": "2.9.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
 					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-					"dev": true,
-					"requires": {
-						"graceful-readlink": "1.0.1"
-					}
+					"dev": true
 				},
 				"debug": {
 					"version": "2.6.8",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
+					"dev": true
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
 					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-					"dev": true,
-					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.17"
-					}
+					"dev": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
 					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-					"dev": true,
-					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
-					}
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
 				},
 				"minimist": {
 					"version": "1.2.0",
@@ -1828,49 +1183,19 @@
 					"version": "2.81.0",
 					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
 					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-					"dev": true,
-					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.17",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.1.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.3",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.1.0"
-					}
+					"dev": true
 				},
 				"supports-color": {
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
-					"requires": {
-						"has-flag": "2.0.0"
-					}
+					"dev": true
 				},
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "5.1.1"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -1879,9 +1204,6 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
-			"requires": {
-				"assert-plus": "1.0.0"
-			},
 			"dependencies": {
 				"assert-plus": {
 					"version": "1.0.0",
@@ -1907,20 +1229,13 @@
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
 			"integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-			"dev": true,
-			"requires": {
-				"get-stdin": "4.0.1",
-				"meow": "3.7.0"
-			}
+			"dev": true
 		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"requires": {
-				"ms": "2.0.0"
-			}
+			"dev": true
 		},
 		"decamelize": {
 			"version": "1.2.0",
@@ -1944,16 +1259,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-			"dev": true,
-			"requires": {
-				"globby": "5.0.0",
-				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.0",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"rimraf": "2.2.8"
-			}
+			"dev": true
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
@@ -1964,41 +1270,32 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
 			"integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
-			"dev": true,
-			"requires": {
-				"JSONStream": "1.3.1",
-				"shasum": "1.0.2",
-				"subarg": "1.0.0",
-				"through2": "2.0.3"
-			}
+			"dev": true
 		},
 		"des.js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-			"dev": true,
-			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
-			}
+			"dev": true
 		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"dev": true,
-			"requires": {
-				"repeating": "2.0.1"
-			}
+			"dev": true
 		},
 		"detective": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
-			"integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+			"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
 			"dev": true,
-			"requires": {
-				"acorn": "4.0.13",
-				"defined": "1.0.0"
+			"dependencies": {
+				"acorn": {
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+					"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+					"dev": true
+				}
 			}
 		},
 		"diff": {
@@ -2011,22 +1308,13 @@
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
 			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-			"dev": true,
-			"requires": {
-				"bn.js": "4.11.8",
-				"miller-rabin": "4.0.1",
-				"randombytes": "2.0.5"
-			}
+			"dev": true
 		},
 		"doctrine": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 			"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-			"dev": true,
-			"requires": {
-				"esutils": "2.0.2",
-				"isarray": "1.0.0"
-			}
+			"dev": true
 		},
 		"domain-browser": {
 			"version": "1.1.7",
@@ -2038,32 +1326,20 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
 			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "2.3.3"
-			}
+			"dev": true
 		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 			"dev": true,
-			"optional": true,
-			"requires": {
-				"jsbn": "0.1.1"
-			}
+			"optional": true
 		},
 		"ecstatic": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-2.2.1.tgz",
 			"integrity": "sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==",
 			"dev": true,
-			"requires": {
-				"he": "1.1.1",
-				"mime": "1.4.1",
-				"minimist": "1.2.0",
-				"url-join": "2.0.2"
-			},
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
@@ -2076,15 +1352,12 @@
 		"ed2curve": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.2.1.tgz",
-			"integrity": "sha1-Iuaqo1aePE2/Tu+ilhLsMp5YGQw=",
-			"requires": {
-				"tweetnacl": "0.14.5"
-			}
+			"integrity": "sha1-Iuaqo1aePE2/Tu+ilhLsMp5YGQw="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.27",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-			"integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
+			"version": "1.3.33",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
+			"integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU=",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -2097,25 +1370,13 @@
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-			"dev": true,
-			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0",
-				"hash.js": "1.1.3",
-				"hmac-drbg": "1.0.1",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
-			}
+			"dev": true
 		},
 		"error-ex": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-			"dev": true,
-			"requires": {
-				"is-arrayish": "0.2.1"
-			}
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -2124,61 +1385,16 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.11.0.tgz",
-			"integrity": "sha512-UWbhQpaKlm8h5x/VLwm0S1kheMrDj8jPwhnBMjr/Dlo3qqT7MvcN/UfKAR3E1N4lr4YNtOvS4m3hwsrVc/ky7g==",
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.17.0.tgz",
+			"integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
 			"dev": true,
-			"requires": {
-				"ajv": "5.3.0",
-				"babel-code-frame": "6.26.0",
-				"chalk": "2.3.0",
-				"concat-stream": "1.6.0",
-				"cross-spawn": "5.1.0",
-				"debug": "3.1.0",
-				"doctrine": "2.0.0",
-				"eslint-scope": "3.7.1",
-				"espree": "3.5.2",
-				"esquery": "1.0.0",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"file-entry-cache": "2.0.0",
-				"functional-red-black-tree": "1.0.1",
-				"glob": "7.1.2",
-				"globals": "9.18.0",
-				"ignore": "3.3.7",
-				"imurmurhash": "0.1.4",
-				"inquirer": "3.3.0",
-				"is-resolvable": "1.0.0",
-				"js-yaml": "3.10.0",
-				"json-stable-stringify-without-jsonify": "1.0.1",
-				"levn": "0.3.0",
-				"lodash": "4.17.4",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"optionator": "0.8.2",
-				"path-is-inside": "1.0.2",
-				"pluralize": "7.0.0",
-				"progress": "2.0.0",
-				"require-uncached": "1.0.3",
-				"semver": "5.4.1",
-				"strip-ansi": "4.0.0",
-				"strip-json-comments": "2.0.1",
-				"table": "4.0.2",
-				"text-table": "0.2.0"
-			},
 			"dependencies": {
 				"ajv": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-					"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
-					"dev": true,
-					"requires": {
-						"co": "4.6.0",
-						"fast-deep-equal": "1.0.0",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.3.1"
-					}
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "3.0.0",
@@ -2190,40 +1406,25 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
-					"requires": {
-						"color-convert": "1.9.1"
-					}
+					"dev": true
 				},
 				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
-					}
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
+					"dev": true
 				},
 				"doctrine": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-					"integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-					"dev": true,
-					"requires": {
-						"esutils": "2.0.2",
-						"isarray": "1.0.0"
-					}
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"dev": true
 				},
 				"esprima": {
 					"version": "4.0.0",
@@ -2231,15 +1432,23 @@
 					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
 					"dev": true
 				},
+				"globals": {
+					"version": "11.3.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+					"integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
 				"js-yaml": {
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
 					"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-					"dev": true,
-					"requires": {
-						"argparse": "1.0.9",
-						"esprima": "4.0.0"
-					}
+					"dev": true
 				},
 				"progress": {
 					"version": "2.0.0",
@@ -2251,19 +1460,13 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "3.0.0"
-					}
+					"dev": true
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
-					"requires": {
-						"has-flag": "2.0.0"
-					}
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true
 				}
 			}
 		},
@@ -2271,10 +1474,7 @@
 			"version": "11.3.1",
 			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.1.tgz",
 			"integrity": "sha512-BXVH7PV5yiLjnkv49iOLJ8dWp+ljZf310ytQpqwrunFADiEbWRyN0tPGDU36FgEbdLvhJDWcJOngYDzPF4shDw==",
-			"dev": true,
-			"requires": {
-				"eslint-restricted-globals": "0.1.1"
-			}
+			"dev": true
 		},
 		"eslint-config-lisk-base": {
 			"version": "0.1.0",
@@ -2283,84 +1483,46 @@
 			"dev": true
 		},
 		"eslint-import-resolver-node": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-			"integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"resolve": "1.5.0"
-			}
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+			"dev": true
 		},
 		"eslint-module-utils": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
 			"integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"pkg-dir": "1.0.0"
-			}
+			"dev": true
 		},
 		"eslint-plugin-import": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
 			"integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
 			"dev": true,
-			"requires": {
-				"builtin-modules": "1.1.1",
-				"contains-path": "0.1.0",
-				"debug": "2.6.9",
-				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "0.3.1",
-				"eslint-module-utils": "2.1.1",
-				"has": "1.0.1",
-				"lodash.cond": "4.5.2",
-				"minimatch": "3.0.4",
-				"read-pkg-up": "2.0.0"
-			},
 			"dependencies": {
 				"load-json-file": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"strip-bom": "3.0.0"
-					}
+					"dev": true
 				},
 				"path-type": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"dev": true,
-					"requires": {
-						"pify": "2.3.0"
-					}
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "2.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "2.0.0"
-					}
+					"dev": true
 				},
 				"read-pkg-up": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"dev": true,
-					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "2.0.0"
-					}
+					"dev": true
 				},
 				"strip-bom": {
 					"version": "3.0.0",
@@ -2380,26 +1542,24 @@
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-			"dev": true,
-			"requires": {
-				"esrecurse": "4.2.0",
-				"estraverse": "4.2.0"
-			}
+			"dev": true
+		},
+		"eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
 		},
 		"espree": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-			"integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
+			"integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
 			"dev": true,
-			"requires": {
-				"acorn": "5.2.1",
-				"acorn-jsx": "3.0.1"
-			},
 			"dependencies": {
 				"acorn": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-					"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+					"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
 					"dev": true
 				}
 			}
@@ -2414,20 +1574,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-			"dev": true,
-			"requires": {
-				"estraverse": "4.2.0"
-			}
+			"dev": true
 		},
 		"esrecurse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-			"dev": true,
-			"requires": {
-				"estraverse": "4.2.0",
-				"object-assign": "4.1.1"
-			}
+			"dev": true
 		},
 		"estraverse": {
 			"version": "4.2.0",
@@ -2463,26 +1616,13 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
-			"requires": {
-				"md5.js": "1.3.4",
-				"safe-buffer": "5.1.1"
-			}
+			"dev": true
 		},
 		"execa": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
 			"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-			"dev": true,
-			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
-			}
+			"dev": true
 		},
 		"exit": {
 			"version": "0.1.2",
@@ -2500,19 +1640,13 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-			"dev": true,
-			"requires": {
-				"is-posix-bracket": "0.1.1"
-			}
+			"dev": true
 		},
 		"expand-range": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
-			"requires": {
-				"fill-range": "2.2.3"
-			}
+			"dev": true
 		},
 		"extend": {
 			"version": "3.0.1",
@@ -2521,24 +1655,16 @@
 			"dev": true
 		},
 		"external-editor": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-			"integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
 			"dev": true,
-			"requires": {
-				"iconv-lite": "0.4.19",
-				"jschardet": "1.6.0",
-				"tmp": "0.0.33"
-			},
 			"dependencies": {
 				"tmp": {
 					"version": "0.0.33",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-					"dev": true,
-					"requires": {
-						"os-tmpdir": "1.0.2"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -2546,40 +1672,25 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-			"dev": true,
-			"requires": {
-				"is-extglob": "1.0.0"
-			}
+			"dev": true
 		},
 		"extract-zip": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
 			"integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
 			"dev": true,
-			"requires": {
-				"concat-stream": "1.6.0",
-				"debug": "2.2.0",
-				"mkdirp": "0.5.0",
-				"yauzl": "2.4.1"
-			},
 			"dependencies": {
 				"debug": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
 					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"dev": true,
-					"requires": {
-						"ms": "0.7.1"
-					}
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
 					"integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
+					"dev": true
 				},
 				"ms": {
 					"version": "0.7.1",
@@ -2591,10 +1702,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
 					"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-					"dev": true,
-					"requires": {
-						"fd-slicer": "1.0.1"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -2626,30 +1734,19 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
 			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-			"dev": true,
-			"requires": {
-				"pend": "1.2.0"
-			}
+			"dev": true
 		},
 		"figures": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "1.0.5",
-				"object-assign": "4.1.1"
-			}
+			"dev": true
 		},
 		"file-entry-cache": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-			"dev": true,
-			"requires": {
-				"flat-cache": "1.3.0",
-				"object-assign": "4.1.1"
-			}
+			"dev": true
 		},
 		"filename-regex": {
 			"version": "2.0.1",
@@ -2661,45 +1758,25 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-			"dev": true,
-			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "1.1.7",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
-			}
+			"dev": true
 		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
-			"requires": {
-				"locate-path": "2.0.0"
-			}
+			"dev": true
 		},
 		"findup-sync": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
 			"integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
 			"dev": true,
-			"requires": {
-				"glob": "5.0.15"
-			},
 			"dependencies": {
 				"glob": {
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"dev": true,
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -2707,13 +1784,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-			"dev": true,
-			"requires": {
-				"circular-json": "0.3.3",
-				"del": "2.2.2",
-				"graceful-fs": "4.1.11",
-				"write": "0.2.1"
-			}
+			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -2725,10 +1796,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
-			"requires": {
-				"for-in": "1.0.2"
-			}
+			"dev": true
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -2737,34 +1805,21 @@
 			"dev": true
 		},
 		"form-data": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.5",
-				"mime-types": "2.1.17"
-			}
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk="
 		},
 		"formatio": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
 			"integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-			"dev": true,
-			"requires": {
-				"samsam": "1.3.0"
-			}
+			"dev": true
 		},
 		"fs-extra": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz",
 			"integrity": "sha1-f8DGyJV/mD9X8waiTlud3Y0N2IA=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "3.0.1",
-				"universalify": "0.1.1"
-			}
+			"dev": true
 		},
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
@@ -2784,182 +1839,174 @@
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"dev": true,
 			"optional": true,
-			"requires": {
-				"nan": "2.7.0",
-				"node-pre-gyp": "0.6.39"
-			},
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+					"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
 					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
-					}
+					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
 				},
 				"aproba": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+					"integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.2.9"
-					}
+					"optional": true
 				},
 				"asn1": {
 					"version": "0.2.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
 					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
 					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
 					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
 					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
 					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"tweetnacl": "0.14.5"
-					}
+					"optional": true
 				},
 				"block-stream": {
 					"version": "0.0.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"inherits": "2.0.3"
-					}
+					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+					"dev": true
 				},
 				"boom": {
 					"version": "2.10.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
+					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.7",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"balanced-match": "0.4.2",
-						"concat-map": "0.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+					"dev": true
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
 					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"delayed-stream": "1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"boom": "2.10.1"
-					}
+					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+					"dev": true
 				},
 				"dashdash": {
 					"version": "1.14.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 					"dev": true,
 					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
@@ -2967,128 +2014,109 @@
 				},
 				"debug": {
 					"version": "2.6.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
+					"optional": true
 				},
 				"deep-extend": {
 					"version": "0.4.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
 					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+					"integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
 					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
+					"optional": true
 				},
 				"extend": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
 					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
 					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
 					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.15"
-					}
+					"optional": true
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"inherits": "2.0.3",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1"
-					}
+					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+					"dev": true
 				},
 				"fstream-ignore": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"fstream": "1.0.11",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4"
-					}
+					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"aproba": "1.1.1",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
-					}
+					"optional": true
 				},
 				"getpass": {
 					"version": "0.1.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 					"dev": true,
 					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
@@ -3096,173 +2124,154 @@
 				},
 				"glob": {
 					"version": "7.1.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 					"dev": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
 					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
-					}
+					"optional": true
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
-					}
+					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+					"dev": true
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
 					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.0",
-						"sshpk": "1.13.0"
-					}
+					"optional": true
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
-					}
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"dev": true
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"dev": true
 				},
 				"ini": {
 					"version": "1.3.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+					"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
+					"optional": true
 				},
 				"jsbn": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"jsonify": "0.0.0"
-					}
+					"optional": true
 				},
 				"json-stringify-safe": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
 					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+					"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
 					"dev": true,
 					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.0.2",
-						"json-schema": "0.2.3",
-						"verror": "1.3.6"
-					},
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
@@ -3270,175 +2279,153 @@
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
 					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"mime-db": "1.27.0"
-					}
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"brace-expansion": "1.1.7"
-					}
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"dev": true
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.39",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+					"integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"detect-libc": "1.0.2",
-						"hawk": "3.1.3",
-						"mkdirp": "0.5.1",
-						"nopt": "4.0.1",
-						"npmlog": "4.1.0",
-						"rc": "1.2.1",
-						"request": "2.81.0",
-						"rimraf": "2.6.1",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.4.0"
-					}
+					"optional": true
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1.1.0",
-						"osenv": "0.1.4"
-					}
+					"optional": true
 				},
 				"npmlog": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
-					}
+					"optional": true
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
 					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"wrappy": "1.0.2"
-					}
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"dev": true
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
-					}
+					"optional": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
 					"dev": true
 				},
 				"punycode": {
 					"version": "1.4.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
 					"dev": true,
 					"optional": true,
-					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.4",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
-					},
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true
 						}
@@ -3446,238 +2433,176 @@
 				},
 				"readable-stream": {
 					"version": "2.2.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"buffer-shims": "1.0.0",
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "1.0.1",
-						"util-deprecate": "1.0.2"
-					}
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+					"dev": true
 				},
 				"request": {
 					"version": "2.81.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.15",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.0.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.2",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.0.1"
-					}
+					"optional": true
 				},
 				"rimraf": {
 					"version": "2.6.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"glob": "7.1.2"
-					}
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+					"dev": true
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
 					"dev": true
 				},
 				"semver": {
 					"version": "5.3.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
+					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+					"dev": true
 				},
 				"sshpk": {
 					"version": "1.13.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
 					"dev": true,
 					"optional": true,
-					"requires": {
-						"asn1": "0.2.3",
-						"assert-plus": "1.0.0",
-						"bcrypt-pbkdf": "1.0.1",
-						"dashdash": "1.14.1",
-						"ecc-jsbn": "0.1.1",
-						"getpass": "0.1.7",
-						"jodid25519": "1.0.2",
-						"jsbn": "0.1.1",
-						"tweetnacl": "0.14.5"
-					},
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
 					}
 				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
 				"string_decoder": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true
 				},
 				"stringstream": {
 					"version": "0.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
 					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"block-stream": "0.0.9",
-						"fstream": "1.0.11",
-						"inherits": "2.0.3"
-					}
+					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+					"dev": true
 				},
 				"tar-pack": {
 					"version": "3.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"debug": "2.6.8",
-						"fstream": "1.0.11",
-						"fstream-ignore": "1.0.5",
-						"once": "1.4.0",
-						"readable-stream": "2.2.9",
-						"rimraf": "2.6.1",
-						"tar": "2.2.1",
-						"uid-number": "0.0.6"
-					}
+					"optional": true
 				},
 				"tough-cookie": {
 					"version": "2.3.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"punycode": "1.4.1"
-					}
+					"optional": true
 				},
 				"tunnel-agent": {
 					"version": "0.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
+					"optional": true
 				},
 				"tweetnacl": {
 					"version": "0.14.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
 					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
 					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true
 				},
 				"uuid": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
 					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"extsprintf": "1.0.2"
-					}
+					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"string-width": "1.0.2"
-					}
+					"optional": true
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true
 				}
 			}
@@ -3704,10 +2629,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-			"dev": true,
-			"requires": {
-				"is-property": "1.0.2"
-			}
+			"dev": true
 		},
 		"get-own-enumerable-property-symbols": {
 			"version": "2.0.1",
@@ -3737,19 +2659,13 @@
 			"version": "2.8.4",
 			"resolved": "https://registry.npmjs.org/getos/-/getos-2.8.4.tgz",
 			"integrity": "sha1-e4YD02GcKOOMsP56T2PDrLgNUWM=",
-			"dev": true,
-			"requires": {
-				"async": "2.1.4"
-			}
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
-			"requires": {
-				"assert-plus": "1.0.0"
-			},
 			"dependencies": {
 				"assert-plus": {
 					"version": "1.0.0",
@@ -3763,43 +2679,25 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
-			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
-			}
+			"dev": true
 		},
 		"glob-base": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
-			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
-			}
+			"dev": true
 		},
 		"glob-parent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"dev": true,
-			"requires": {
-				"is-glob": "2.0.1"
-			}
+			"dev": true
 		},
 		"global-dirs": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
-			"integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
-			"dev": true,
-			"requires": {
-				"ini": "1.3.4"
-			}
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"dev": true
 		},
 		"globals": {
 			"version": "9.18.0",
@@ -3811,15 +2709,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-			"dev": true,
-			"requires": {
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"glob": "7.1.2",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
-			}
+			"dev": true
 		},
 		"graceful-fs": {
 			"version": "4.1.11",
@@ -3844,60 +2734,24 @@
 			"resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.1.tgz",
 			"integrity": "sha1-6HeHZOlEsY8yuw8QuQeEdcnftWs=",
 			"dev": true,
-			"requires": {
-				"coffee-script": "1.10.0",
-				"dateformat": "1.0.12",
-				"eventemitter2": "0.4.14",
-				"exit": "0.1.2",
-				"findup-sync": "0.3.0",
-				"glob": "7.0.6",
-				"grunt-cli": "1.2.0",
-				"grunt-known-options": "1.1.0",
-				"grunt-legacy-log": "1.0.0",
-				"grunt-legacy-util": "1.0.0",
-				"iconv-lite": "0.4.19",
-				"js-yaml": "3.5.5",
-				"minimatch": "3.0.4",
-				"nopt": "3.0.6",
-				"path-is-absolute": "1.0.1",
-				"rimraf": "2.2.8"
-			},
 			"dependencies": {
 				"glob": {
 					"version": "7.0.6",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
 					"integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"dev": true
 				},
 				"grunt-cli": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
 					"integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
-					"dev": true,
-					"requires": {
-						"findup-sync": "0.3.0",
-						"grunt-known-options": "1.1.0",
-						"nopt": "3.0.6",
-						"resolve": "1.1.7"
-					}
+					"dev": true
 				},
 				"js-yaml": {
 					"version": "3.5.5",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
 					"integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
-					"dev": true,
-					"requires": {
-						"argparse": "1.0.9",
-						"esprima": "2.7.3"
-					}
+					"dev": true
 				},
 				"resolve": {
 					"version": "1.1.7",
@@ -3912,14 +2766,6 @@
 			"resolved": "https://registry.npmjs.org/grunt-browserify/-/grunt-browserify-5.0.0.tgz",
 			"integrity": "sha1-HTM8qYvaxEV29kbg1mgAh8v4xhU=",
 			"dev": true,
-			"requires": {
-				"async": "1.5.2",
-				"browserify": "13.3.0",
-				"glob": "6.0.4",
-				"lodash": "3.10.1",
-				"resolve": "1.5.0",
-				"watchify": "3.9.0"
-			},
 			"dependencies": {
 				"async": {
 					"version": "1.5.2",
@@ -3931,14 +2777,7 @@
 					"version": "6.0.4",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
 					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-					"dev": true,
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"dev": true
 				},
 				"lodash": {
 					"version": "3.10.1",
@@ -3952,32 +2791,19 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-3.0.1.tgz",
 			"integrity": "sha1-/etfk4pMgEL46Grkb2NVTo6VEcs=",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"maxmin": "1.1.0",
-				"uglify-js": "3.0.28",
-				"uri-path": "1.0.0"
-			}
+			"dev": true
 		},
 		"grunt-coveralls": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/grunt-coveralls/-/grunt-coveralls-1.0.1.tgz",
 			"integrity": "sha1-LwxvA8wfJ/o5ior13XuPR0+DXY0=",
-			"dev": true,
-			"requires": {
-				"coveralls": "2.13.1"
-			}
+			"dev": true
 		},
 		"grunt-eslint": {
 			"version": "20.0.0",
 			"resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-20.0.0.tgz",
 			"integrity": "sha512-jQ2GBIYUkfVict7WcSBH7mAukTJ7Cz5TwJUCQ8XxzVTTyAcxC+1MGM3rdEuQbtsLUNKqy9xr0ai/l14WkxVtkw==",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"eslint": "4.11.0"
-			}
+			"dev": true
 		},
 		"grunt-exec": {
 			"version": "2.0.0",
@@ -3996,13 +2822,6 @@
 			"resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
 			"integrity": "sha1-+4bxgJhHvAfcR4Q/ns1srLYt8tU=",
 			"dev": true,
-			"requires": {
-				"colors": "1.1.2",
-				"grunt-legacy-log-utils": "1.0.0",
-				"hooker": "0.2.3",
-				"lodash": "3.10.1",
-				"underscore.string": "3.2.3"
-			},
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
@@ -4017,10 +2836,6 @@
 			"resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
 			"integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
 			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"lodash": "4.3.0"
-			},
 			"dependencies": {
 				"lodash": {
 					"version": "4.3.0",
@@ -4035,15 +2850,6 @@
 			"resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
 			"integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
 			"dev": true,
-			"requires": {
-				"async": "1.5.2",
-				"exit": "0.1.2",
-				"getobject": "0.1.0",
-				"hooker": "0.2.3",
-				"lodash": "4.3.0",
-				"underscore.string": "3.2.3",
-				"which": "1.2.14"
-			},
 			"dependencies": {
 				"async": {
 					"version": "1.5.2",
@@ -4063,11 +2869,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
 			"integrity": "sha1-Zs+LEBBHInuVus5uodoMF37Vwi8=",
-			"dev": true,
-			"requires": {
-				"browserify-zlib": "0.1.4",
-				"concat-stream": "1.6.0"
-			}
+			"dev": true
 		},
 		"har-schema": {
 			"version": "1.0.5",
@@ -4079,31 +2881,19 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
 			"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"commander": "2.11.0",
-				"is-my-json-valid": "2.16.1",
-				"pinkie-promise": "2.0.1"
-			}
+			"dev": true
 		},
 		"has": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-			"dev": true,
-			"requires": {
-				"function-bind": "1.1.1"
-			}
+			"dev": true
 		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "2.1.1"
-			}
+			"dev": true
 		},
 		"has-flag": {
 			"version": "2.0.0",
@@ -4114,32 +2904,19 @@
 		"hash-base": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-			"requires": {
-				"inherits": "2.0.3"
-			}
+			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE="
 		},
 		"hash.js": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-			"dev": true,
-			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
-			}
+			"dev": true
 		},
 		"hawk": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-			"dev": true,
-			"requires": {
-				"boom": "2.10.1",
-				"cryptiles": "2.0.5",
-				"hoek": "2.16.3",
-				"sntp": "1.0.9"
-			}
+			"dev": true
 		},
 		"he": {
 			"version": "1.1.1",
@@ -4151,12 +2928,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"dev": true,
-			"requires": {
-				"hash.js": "1.1.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
-			}
+			"dev": true
 		},
 		"hoek": {
 			"version": "2.16.3",
@@ -4168,11 +2940,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"dev": true,
-			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
-			}
+			"dev": true
 		},
 		"hooker": {
 			"version": "0.2.3",
@@ -4196,27 +2964,13 @@
 			"version": "1.16.2",
 			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
 			"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-			"dev": true,
-			"requires": {
-				"eventemitter3": "1.2.0",
-				"requires-port": "1.0.0"
-			}
+			"dev": true
 		},
 		"http-server": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/http-server/-/http-server-0.10.0.tgz",
 			"integrity": "sha1-sqRGsWqduH7TxiK6m+sbCFsSNKc=",
 			"dev": true,
-			"requires": {
-				"colors": "1.0.3",
-				"corser": "2.0.1",
-				"ecstatic": "2.2.1",
-				"http-proxy": "1.16.2",
-				"opener": "1.4.3",
-				"optimist": "0.6.1",
-				"portfinder": "1.0.13",
-				"union": "0.4.6"
-			},
 			"dependencies": {
 				"colors": {
 					"version": "1.0.3",
@@ -4230,12 +2984,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "0.2.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.13.1"
-			}
+			"dev": true
 		},
 		"https-browserify": {
 			"version": "0.0.1",
@@ -4248,11 +2997,6 @@
 			"resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
 			"integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
 			"dev": true,
-			"requires": {
-				"is-ci": "1.0.10",
-				"normalize-path": "1.0.0",
-				"strip-indent": "2.0.0"
-			},
 			"dependencies": {
 				"normalize-path": {
 					"version": "1.0.0",
@@ -4296,10 +3040,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-			"dev": true,
-			"requires": {
-				"repeating": "2.0.1"
-			}
+			"dev": true
 		},
 		"indexof": {
 			"version": "0.0.1",
@@ -4311,11 +3052,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
-			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
-			}
+			"dev": true
 		},
 		"inherits": {
 			"version": "2.0.3",
@@ -4323,41 +3060,22 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"ini": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-			"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 			"dev": true
 		},
 		"inline-source-map": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
 			"integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
-			"dev": true,
-			"requires": {
-				"source-map": "0.5.7"
-			}
+			"dev": true
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
-			"requires": {
-				"ansi-escapes": "3.0.0",
-				"chalk": "2.3.0",
-				"cli-cursor": "2.1.0",
-				"cli-width": "2.2.0",
-				"external-editor": "2.0.5",
-				"figures": "2.0.0",
-				"lodash": "4.17.4",
-				"mute-stream": "0.0.7",
-				"run-async": "2.3.0",
-				"rx-lite": "4.0.8",
-				"rx-lite-aggregates": "4.0.8",
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"through": "2.3.8"
-			},
 			"dependencies": {
 				"ansi-escapes": {
 					"version": "3.0.0",
@@ -4375,39 +3093,31 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
-					"requires": {
-						"color-convert": "1.9.1"
-					}
+					"dev": true
 				},
 				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
-					}
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true
 				},
 				"cli-cursor": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "2.0.0"
-					}
+					"dev": true
 				},
 				"figures": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "1.0.5"
-					}
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
@@ -4419,48 +3129,31 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "1.1.0"
-					}
+					"dev": true
 				},
 				"restore-cursor": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-					"dev": true,
-					"requires": {
-						"onetime": "2.0.1",
-						"signal-exit": "3.0.2"
-					}
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
-					}
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "3.0.0"
-					}
+					"dev": true
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
-					"requires": {
-						"has-flag": "2.0.0"
-					}
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true
 				}
 			}
 		},
@@ -4469,41 +3162,36 @@
 			"resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
 			"integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
 			"dev": true,
-			"requires": {
-				"JSONStream": "1.3.1",
-				"combine-source-map": "0.7.2",
-				"concat-stream": "1.5.2",
-				"is-buffer": "1.1.6",
-				"lexical-scope": "1.2.0",
-				"process": "0.11.10",
-				"through2": "2.0.3",
-				"xtend": "4.0.1"
-			},
 			"dependencies": {
+				"combine-source-map": {
+					"version": "0.7.2",
+					"resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+					"integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
+					"dev": true
+				},
 				"concat-stream": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
 					"integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
-					"dev": true,
-					"requires": {
-						"inherits": "2.0.3",
-						"readable-stream": "2.0.6",
-						"typedarray": "0.0.6"
-					}
+					"dev": true
+				},
+				"convert-source-map": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+					"integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+					"dev": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+					"dev": true
 				},
 				"readable-stream": {
 					"version": "2.0.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
 					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "0.10.31",
-						"util-deprecate": "1.0.2"
-					}
+					"dev": true
 				},
 				"string_decoder": {
 					"version": "0.10.31",
@@ -4517,10 +3205,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-			"dev": true,
-			"requires": {
-				"loose-envify": "1.3.1"
-			}
+			"dev": true
 		},
 		"invert-kv": {
 			"version": "1.0.0",
@@ -4538,10 +3223,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"dev": true,
-			"requires": {
-				"binary-extensions": "1.10.0"
-			}
+			"dev": true
 		},
 		"is-buffer": {
 			"version": "1.1.6",
@@ -4553,19 +3235,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
-			"requires": {
-				"builtin-modules": "1.1.1"
-			}
+			"dev": true
 		},
 		"is-ci": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
 			"integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-			"dev": true,
-			"requires": {
-				"ci-info": "1.1.1"
-			}
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
@@ -4577,10 +3253,7 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
-			"requires": {
-				"is-primitive": "2.0.0"
-			}
+			"dev": true
 		},
 		"is-extendable": {
 			"version": "0.1.1",
@@ -4598,59 +3271,43 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "1.0.1"
-			}
+			"dev": true
 		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "1.0.1"
-			}
+			"dev": true
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"dev": true,
-			"requires": {
-				"is-extglob": "1.0.0"
-			}
+			"dev": true
 		},
 		"is-installed-globally": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
 			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-			"dev": true,
-			"requires": {
-				"global-dirs": "0.1.0",
-				"is-path-inside": "1.0.0"
-			}
+			"dev": true
+		},
+		"is-my-ip-valid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+			"dev": true
 		},
 		"is-my-json-valid": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-			"integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
-			"dev": true,
-			"requires": {
-				"generate-function": "2.0.0",
-				"generate-object-property": "1.2.0",
-				"jsonpointer": "4.0.1",
-				"xtend": "4.0.1"
-			}
+			"version": "2.17.2",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+			"integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+			"dev": true
 		},
 		"is-number": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-			"dev": true,
-			"requires": {
-				"kind-of": "3.2.2"
-			}
+			"dev": true
 		},
 		"is-obj": {
 			"version": "1.0.1",
@@ -4668,19 +3325,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-			"dev": true,
-			"requires": {
-				"is-path-inside": "1.0.0"
-			}
+			"dev": true
 		},
 		"is-path-inside": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-			"dev": true,
-			"requires": {
-				"path-is-inside": "1.0.2"
-			}
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true
 		},
 		"is-posix-bracket": {
 			"version": "0.1.1",
@@ -4713,13 +3364,10 @@
 			"dev": true
 		},
 		"is-resolvable": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-			"integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-			"dev": true,
-			"requires": {
-				"tryit": "1.0.3"
-			}
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -4754,10 +3402,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"dev": true,
-			"requires": {
-				"isarray": "1.0.0"
-			}
+			"dev": true
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -4766,25 +3411,16 @@
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-			"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz",
+			"integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w==",
 			"dev": true
 		},
 		"istanbul-lib-instrument": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
-			"integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
-			"dev": true,
-			"requires": {
-				"babel-generator": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"istanbul-lib-coverage": "1.1.1",
-				"semver": "5.4.1"
-			}
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz",
+			"integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
+			"dev": true
 		},
 		"jest-get-type": {
 			"version": "21.2.0",
@@ -4797,41 +3433,30 @@
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
 			"integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
 			"dev": true,
-			"requires": {
-				"chalk": "2.3.0",
-				"jest-get-type": "21.2.0",
-				"leven": "2.1.0",
-				"pretty-format": "21.2.1"
-			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
-					"requires": {
-						"color-convert": "1.9.1"
-					}
+					"dev": true
 				},
 				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
-					}
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
-					"requires": {
-						"has-flag": "2.0.0"
-					}
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true
 				}
 			}
 		},
@@ -4848,11 +3473,7 @@
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
 			"integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-			"dev": true,
-			"requires": {
-				"argparse": "1.0.9",
-				"esprima": "2.7.3"
-			}
+			"dev": true
 		},
 		"jsbn": {
 			"version": "0.1.1",
@@ -4860,12 +3481,6 @@
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 			"dev": true,
 			"optional": true
-		},
-		"jschardet": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
-			"integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
-			"dev": true
 		},
 		"jsesc": {
 			"version": "1.3.0",
@@ -4889,10 +3504,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
-			"requires": {
-				"jsonify": "0.0.0"
-			}
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -4922,10 +3534,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
 			"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "4.1.11"
-			}
+			"dev": true
 		},
 		"jsonify": {
 			"version": "0.0.0",
@@ -4945,17 +3554,17 @@
 			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
 			"dev": true
 		},
+		"JSONStream": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+			"dev": true
+		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
 			"dev": true,
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			},
 			"dependencies": {
 				"assert-plus": {
 					"version": "1.0.0",
@@ -4969,21 +3578,13 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
-			"requires": {
-				"is-buffer": "1.1.6"
-			}
+			"dev": true
 		},
 		"labeled-stream-splicer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
 			"integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
 			"dev": true,
-			"requires": {
-				"inherits": "2.0.3",
-				"isarray": "0.0.1",
-				"stream-splicer": "2.0.0"
-			},
 			"dependencies": {
 				"isarray": {
 					"version": "0.0.1",
@@ -4997,10 +3598,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
-			"requires": {
-				"invert-kv": "1.0.0"
-			}
+			"dev": true
 		},
 		"lcov-parse": {
 			"version": "0.0.10",
@@ -5018,62 +3616,37 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true,
-			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
-			}
+			"dev": true
 		},
 		"lexical-scope": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
 			"integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
-			"dev": true,
-			"requires": {
-				"astw": "2.2.0"
-			}
+			"dev": true
 		},
 		"lint-staged": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-4.2.3.tgz",
 			"integrity": "sha512-Ks1vMyVpp3ldeFDN9sIcHcFDh0v3X6Y6LOdT0Wl86/BSDM2R8PVcuFODkh0Dav7Ni/asUPKONfXRWZM9YO85IQ==",
 			"dev": true,
-			"requires": {
-				"app-root-path": "2.0.1",
-				"chalk": "2.3.0",
-				"cosmiconfig": "1.1.0",
-				"execa": "0.8.0",
-				"is-glob": "4.0.0",
-				"jest-validate": "21.2.1",
-				"listr": "0.12.0",
-				"lodash": "4.17.4",
-				"log-symbols": "2.1.0",
-				"minimatch": "3.0.4",
-				"npm-which": "3.0.1",
-				"p-map": "1.2.0",
-				"staged-git-files": "0.0.4",
-				"stringify-object": "3.2.1"
-			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
-					"requires": {
-						"color-convert": "1.9.1"
-					}
+					"dev": true
 				},
 				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
-					}
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"is-extglob": {
 					"version": "2.1.1",
@@ -5085,28 +3658,19 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "2.1.1"
-					}
+					"dev": true
 				},
 				"log-symbols": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
-					"integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "2.3.0"
-					}
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+					"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+					"dev": true
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
-					"requires": {
-						"has-flag": "2.0.0"
-					}
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true
 				}
 			}
 		},
@@ -5114,25 +3678,7 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
 			"integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"cli-truncate": "0.2.1",
-				"figures": "1.7.0",
-				"indent-string": "2.1.0",
-				"is-promise": "2.1.0",
-				"is-stream": "1.1.0",
-				"listr-silent-renderer": "1.1.1",
-				"listr-update-renderer": "0.2.0",
-				"listr-verbose-renderer": "0.4.1",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"ora": "0.2.3",
-				"p-map": "1.2.0",
-				"rxjs": "5.5.2",
-				"stream-to-observable": "0.1.0",
-				"strip-ansi": "3.0.1"
-			}
+			"dev": true
 		},
 		"listr-silent-renderer": {
 			"version": "1.1.1",
@@ -5145,16 +3691,6 @@
 			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
 			"integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
 			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"cli-truncate": "0.2.1",
-				"elegant-spinner": "1.0.1",
-				"figures": "1.7.0",
-				"indent-string": "3.2.0",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"strip-ansi": "3.0.1"
-			},
 			"dependencies": {
 				"indent-string": {
 					"version": "3.2.0",
@@ -5168,64 +3704,37 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"date-fns": "1.29.0",
-				"figures": "1.7.0"
-			}
+			"dev": true
 		},
 		"load-grunt-tasks": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.5.2.tgz",
 			"integrity": "sha1-ByhWEYD9IP+KaSdQWFL8WKrqDIg=",
-			"dev": true,
-			"requires": {
-				"arrify": "1.0.1",
-				"multimatch": "2.1.0",
-				"pkg-up": "1.0.0",
-				"resolve-pkg": "0.1.0"
-			}
+			"dev": true
 		},
 		"load-json-file": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0"
-			}
+			"dev": true
 		},
 		"locate-path": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
-			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
-			}
+			"dev": true
 		},
 		"lodash": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
 			"dev": true
 		},
 		"lodash._baseassign": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
 			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-			"dev": true,
-			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash.keys": "3.1.2"
-			}
+			"dev": true
 		},
 		"lodash._basecopy": {
 			"version": "3.0.1",
@@ -5261,12 +3770,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
 			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-			"dev": true,
-			"requires": {
-				"lodash._baseassign": "3.2.0",
-				"lodash._basecreate": "3.0.3",
-				"lodash._isiterateecall": "3.0.9"
-			}
+			"dev": true
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -5284,12 +3788,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"dev": true,
-			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
-			}
+			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "3.0.4",
@@ -5307,20 +3806,13 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 			"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3"
-			}
+			"dev": true
 		},
 		"log-update": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-			"dev": true,
-			"requires": {
-				"ansi-escapes": "1.4.0",
-				"cli-cursor": "1.0.2"
-			}
+			"dev": true
 		},
 		"lolex": {
 			"version": "1.6.0",
@@ -5332,43 +3824,29 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-			"dev": true,
-			"requires": {
-				"js-tokens": "3.0.2"
-			}
+			"dev": true
 		},
 		"loud-rejection": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"dev": true,
-			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
-			}
+			"dev": true
 		},
 		"lru-cache": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-			"dev": true,
-			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
-			}
+			"dev": true
 		},
 		"make-error": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-			"integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y="
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+			"integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
 		},
 		"make-error-cause": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
-			"integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
-			"requires": {
-				"make-error": "1.3.0"
-			}
+			"integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0="
 		},
 		"map-obj": {
 			"version": "1.0.1",
@@ -5380,33 +3858,19 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
 			"integrity": "sha1-cTZehKmd2Piz99X94vANHn9zvmE=",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"figures": "1.7.0",
-				"gzip-size": "1.0.0",
-				"pretty-bytes": "1.0.4"
-			}
+			"dev": true
 		},
 		"md5.js": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
 			"dev": true,
-			"requires": {
-				"hash-base": "3.0.4",
-				"inherits": "2.0.3"
-			},
 			"dependencies": {
 				"hash-base": {
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
 					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-					"dev": true,
-					"requires": {
-						"inherits": "2.0.3",
-						"safe-buffer": "5.1.1"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -5415,18 +3879,6 @@
 			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
-			"requires": {
-				"camelcase-keys": "2.1.0",
-				"decamelize": "1.2.0",
-				"loud-rejection": "1.6.0",
-				"map-obj": "1.0.1",
-				"minimist": "1.2.0",
-				"normalize-package-data": "2.4.0",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"redent": "1.0.0",
-				"trim-newlines": "1.0.0"
-			},
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
@@ -5440,37 +3892,18 @@
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-			"dev": true,
-			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
-			}
+			"dev": true
 		},
 		"miller-rabin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
-			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0"
-			}
+			"dev": true
 		},
 		"mime": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
 			"dev": true
 		},
 		"mime-db": {
@@ -5481,15 +3914,12 @@
 		"mime-types": {
 			"version": "2.1.17",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-			"requires": {
-				"mime-db": "1.30.0"
-			}
+			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo="
 		},
 		"mimic-fn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
 			"dev": true
 		},
 		"minimalistic-assert": {
@@ -5508,10 +3938,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
-			"requires": {
-				"brace-expansion": "1.1.8"
-			}
+			"dev": true
 		},
 		"minimist": {
 			"version": "0.0.8",
@@ -5523,61 +3950,31 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
-			"requires": {
-				"minimist": "0.0.8"
-			}
+			"dev": true
 		},
 		"mocha": {
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
 			"integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
 			"dev": true,
-			"requires": {
-				"browser-stdout": "1.3.0",
-				"commander": "2.9.0",
-				"debug": "2.6.0",
-				"diff": "3.2.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.1",
-				"growl": "1.9.2",
-				"json3": "3.3.2",
-				"lodash.create": "3.1.1",
-				"mkdirp": "0.5.1",
-				"supports-color": "3.1.2"
-			},
 			"dependencies": {
 				"commander": {
 					"version": "2.9.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
 					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-					"dev": true,
-					"requires": {
-						"graceful-readlink": "1.0.1"
-					}
+					"dev": true
 				},
 				"debug": {
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
 					"integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-					"dev": true,
-					"requires": {
-						"ms": "0.7.2"
-					}
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.1",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
 					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"dev": true
 				},
 				"has-flag": {
 					"version": "1.0.0",
@@ -5595,10 +3992,7 @@
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
 					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-					"dev": true,
-					"requires": {
-						"has-flag": "1.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -5613,50 +4007,26 @@
 			"resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
 			"integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
 			"dev": true,
-			"requires": {
-				"JSONStream": "1.3.1",
-				"browser-resolve": "1.11.2",
-				"cached-path-relative": "1.0.1",
-				"concat-stream": "1.5.2",
-				"defined": "1.0.0",
-				"detective": "4.5.0",
-				"duplexer2": "0.1.4",
-				"inherits": "2.0.3",
-				"parents": "1.0.1",
-				"readable-stream": "2.3.3",
-				"resolve": "1.5.0",
-				"stream-combiner2": "1.1.1",
-				"subarg": "1.0.0",
-				"through2": "2.0.3",
-				"xtend": "4.0.1"
-			},
 			"dependencies": {
 				"concat-stream": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
 					"integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
 					"dev": true,
-					"requires": {
-						"inherits": "2.0.3",
-						"readable-stream": "2.0.6",
-						"typedarray": "0.0.6"
-					},
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.0.6",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
 							"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-							"dev": true,
-							"requires": {
-								"core-util-is": "1.0.2",
-								"inherits": "2.0.3",
-								"isarray": "1.0.0",
-								"process-nextick-args": "1.0.7",
-								"string_decoder": "0.10.31",
-								"util-deprecate": "1.0.2"
-							}
+							"dev": true
 						}
 					}
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+					"dev": true
 				},
 				"string_decoder": {
 					"version": "0.10.31",
@@ -5676,13 +4046,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-			"dev": true,
-			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
-			}
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
@@ -5691,9 +4055,9 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+			"integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
 			"dev": true,
 			"optional": true
 		},
@@ -5713,60 +4077,37 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-			"dev": true,
-			"requires": {
-				"abbrev": "1.1.1"
-			}
+			"dev": true
 		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-			"dev": true,
-			"requires": {
-				"hosted-git-info": "2.5.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.4.1",
-				"validate-npm-package-license": "3.0.1"
-			}
+			"dev": true
 		},
 		"normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
-			"requires": {
-				"remove-trailing-separator": "1.1.0"
-			}
+			"dev": true
 		},
 		"npm-path": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
-			"integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
-			"dev": true,
-			"requires": {
-				"which": "1.2.14"
-			}
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+			"integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+			"dev": true
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
-			"requires": {
-				"path-key": "2.0.1"
-			}
+			"dev": true
 		},
 		"npm-which": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
 			"integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
-			"dev": true,
-			"requires": {
-				"commander": "2.11.0",
-				"npm-path": "2.0.3",
-				"which": "1.2.14"
-			}
+			"dev": true
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
@@ -5779,269 +4120,182 @@
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.3.0.tgz",
 			"integrity": "sha512-oUu0WHt1k/JMIODvAYXX6C50Mupw2GO34P/Jdg2ty9xrLufBthHiKR2gf08aF+9S0abW1fl24R7iKRBXzibZmg==",
 			"dev": true,
-			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "1.0.1",
-				"convert-source-map": "1.5.0",
-				"debug-log": "1.0.1",
-				"default-require-extensions": "1.0.0",
-				"find-cache-dir": "0.1.1",
-				"find-up": "2.1.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.1.1",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.9.1",
-				"istanbul-lib-report": "1.1.2",
-				"istanbul-lib-source-maps": "1.2.2",
-				"istanbul-reports": "1.1.3",
-				"md5-hex": "1.3.0",
-				"merge-source-map": "1.0.4",
-				"micromatch": "2.3.11",
-				"mkdirp": "0.5.1",
-				"resolve-from": "2.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.3.8",
-				"test-exclude": "4.1.1",
-				"yargs": "10.0.3",
-				"yargs-parser": "8.0.0"
-			},
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
-					}
+					"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+					"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+					"dev": true
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+					"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
 					"dev": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
 					"dev": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"default-require-extensions": "1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+					"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+					"dev": true
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
 					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"arr-flatten": "1.1.0"
-					}
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+					"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
 					"dev": true
 				},
 				"array-unique": {
 					"version": "0.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
 					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
 					"dev": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"chalk": "1.1.3",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
-					}
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+					"dev": true
 				},
 				"babel-generator": {
 					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"detect-indent": "4.0.0",
-						"jsesc": "1.3.0",
-						"lodash": "4.17.4",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+					"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+					"dev": true
 				},
 				"babel-messages": {
 					"version": "6.23.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "6.26.0"
-					}
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+					"dev": true
 				},
 				"babel-runtime": {
 					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"core-js": "2.5.1",
-						"regenerator-runtime": "0.11.0"
-					}
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+					"dev": true
 				},
 				"babel-template": {
 					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"lodash": "4.17.4"
-					}
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+					"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+					"dev": true
 				},
 				"babel-traverse": {
 					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"debug": "2.6.9",
-						"globals": "9.18.0",
-						"invariant": "2.2.2",
-						"lodash": "4.17.4"
-					}
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+					"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+					"dev": true
 				},
 				"babel-types": {
 					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "6.26.0",
-						"esutils": "2.0.2",
-						"lodash": "4.17.4",
-						"to-fast-properties": "1.0.3"
-					}
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+					"dev": true
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
 					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.8",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"balanced-match": "1.0.0",
-						"concat-map": "0.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+					"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+					"dev": true
 				},
 				"braces": {
 					"version": "1.8.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"expand-range": "1.8.2",
-						"preserve": "0.2.0",
-						"repeat-element": "1.1.2"
-					}
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 					"dev": true
 				},
 				"caching-transform": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"md5-hex": "1.3.0",
-						"mkdirp": "0.5.1",
-						"write-file-atomic": "1.3.4"
-					}
+					"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+					"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+					"dev": true
 				},
 				"camelcase": {
 					"version": "1.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
 					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+					"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
-					}
+					"optional": true
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true
 				},
 				"cliui": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
 					"dev": true,
 					"optional": true,
-					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
-						"wordwrap": "0.0.2"
-					},
 					"dependencies": {
 						"wordwrap": {
 							"version": "0.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+							"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
 							"dev": true,
 							"optional": true
 						}
@@ -6049,1303 +4303,1089 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+					"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
 					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
 					"dev": true
 				},
 				"core-js": {
 					"version": "2.5.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+					"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
 					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"lru-cache": "4.1.1",
-						"which": "1.3.0"
-					}
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+					"dev": true
 				},
 				"debug": {
 					"version": "2.6.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+					"integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
 					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"strip-bom": "2.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+					"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+					"dev": true
 				},
 				"detect-indent": {
 					"version": "4.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"repeating": "2.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+					"dev": true
 				},
 				"error-ex": {
 					"version": "1.3.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-arrayish": "0.2.1"
-					}
+					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+					"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+					"dev": true
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 					"dev": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"dev": true,
-					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
-					},
 					"dependencies": {
 						"cross-spawn": {
 							"version": "5.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"lru-cache": "4.1.1",
-								"shebang-command": "1.2.0",
-								"which": "1.3.0"
-							}
+							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+							"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+							"dev": true
 						}
 					}
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-posix-bracket": "0.1.1"
-					}
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true
 				},
 				"expand-range": {
 					"version": "1.8.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"fill-range": "2.2.3"
-					}
+					"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+					"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+					"dev": true
 				},
 				"extglob": {
 					"version": "0.3.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true
 				},
 				"filename-regex": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+					"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
 					"dev": true
 				},
 				"fill-range": {
 					"version": "2.2.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-number": "2.1.0",
-						"isobject": "2.1.0",
-						"randomatic": "1.1.7",
-						"repeat-element": "1.1.2",
-						"repeat-string": "1.6.1"
-					}
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+					"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+					"dev": true
 				},
 				"find-cache-dir": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"commondir": "1.0.1",
-						"mkdirp": "0.5.1",
-						"pkg-dir": "1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+					"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+					"dev": true
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"locate-path": "2.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 					"dev": true
 				},
 				"for-own": {
 					"version": "0.1.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"for-in": "1.0.2"
-					}
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+					"dev": true
 				},
 				"foreground-child": {
 					"version": "1.5.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
-					}
+					"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+					"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+					"dev": true
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
 					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true
 				},
 				"glob-base": {
 					"version": "0.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"glob-parent": "2.0.0",
-						"is-glob": "2.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+					"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+					"dev": true
 				},
 				"glob-parent": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-glob": "2.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
 					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+					"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 					"dev": true,
-					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
-					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.4.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"amdefine": "1.0.1"
-							}
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+							"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+							"dev": true
 						}
 					}
 				},
 				"has-ansi": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
+					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+					"dev": true
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
 					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.5.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+					"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
 					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
-					}
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"dev": true
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"loose-envify": "1.3.1"
-					}
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+					"dev": true
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 					"dev": true
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
 					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"builtin-modules": "1.1.1"
-					}
+					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+					"dev": true
 				},
 				"is-dotfile": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+					"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
 					"dev": true
 				},
 				"is-equal-shallow": {
 					"version": "0.1.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-primitive": "2.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+					"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+					"dev": true
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
 					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
 					"dev": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true
 				},
 				"is-number": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2"
-					}
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"dev": true
 				},
 				"is-posix-bracket": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+					"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
 					"dev": true
 				},
 				"is-primitive": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+					"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
 					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 					"dev": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+					"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
 					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 					"dev": true
 				},
 				"isobject": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"isarray": "1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+					"dev": true
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+					"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
 					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"append-transform": "0.4.0"
-					}
+					"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+					"integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+					"dev": true
 				},
 				"istanbul-lib-instrument": {
 					"version": "1.9.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-generator": "6.26.0",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"istanbul-lib-coverage": "1.1.1",
-						"semver": "5.4.1"
-					}
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
+					"integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
+					"dev": true
 				},
 				"istanbul-lib-report": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
+					"integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
 					"dev": true,
-					"requires": {
-						"istanbul-lib-coverage": "1.1.1",
-						"mkdirp": "0.5.1",
-						"path-parse": "1.0.5",
-						"supports-color": "3.2.3"
-					},
 					"dependencies": {
 						"supports-color": {
 							"version": "3.2.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"has-flag": "1.0.0"
-							}
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"dev": true
 						}
 					}
 				},
 				"istanbul-lib-source-maps": {
 					"version": "1.2.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
+					"integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
 					"dev": true,
-					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.1.1",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
-					},
 					"dependencies": {
 						"debug": {
 							"version": "3.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
+							"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+							"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+							"dev": true
 						}
 					}
 				},
 				"istanbul-reports": {
 					"version": "1.1.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"handlebars": "4.0.11"
-					}
+					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
+					"integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
+					"dev": true
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
 					"dev": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
 					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-buffer": "1.1.5"
-					}
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true
 				},
 				"lazy-cache": {
 					"version": "1.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+					"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
 					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"invert-kv": "1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+					"dev": true
 				},
 				"load-json-file": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true
 				},
 				"locate-path": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
-					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
-					},
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 							"dev": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
 					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+					"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
 					"dev": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"js-tokens": "3.0.2"
-					}
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"dev": true
 				},
 				"lru-cache": {
 					"version": "4.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
-					}
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+					"dev": true
 				},
 				"md5-hex": {
 					"version": "1.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"md5-o-matic": "0.1.1"
-					}
+					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+					"dev": true
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+					"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
 					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"mimic-fn": "1.1.0"
-					}
+					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+					"dev": true
 				},
 				"merge-source-map": {
 					"version": "1.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"source-map": "0.5.7"
-					}
+					"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+					"integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+					"dev": true
 				},
 				"micromatch": {
 					"version": "2.3.11",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"arr-diff": "2.0.0",
-						"array-unique": "0.2.1",
-						"braces": "1.8.5",
-						"expand-brackets": "0.1.5",
-						"extglob": "0.3.2",
-						"filename-regex": "2.0.1",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1",
-						"kind-of": "3.2.2",
-						"normalize-path": "2.1.1",
-						"object.omit": "2.0.1",
-						"parse-glob": "3.0.4",
-						"regex-cache": "0.4.4"
-					}
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+					"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
 					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"brace-expansion": "1.1.8"
-					}
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"dev": true
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "2.5.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.4.1",
-						"validate-npm-package-license": "3.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+					"dev": true
 				},
 				"normalize-path": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"remove-trailing-separator": "1.1.0"
-					}
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"path-key": "2.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"dev": true
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true
 				},
 				"object.omit": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"for-own": "0.1.5",
-						"is-extendable": "0.1.1"
-					}
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+					"dev": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"wrappy": "1.0.2"
-					}
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"dev": true
 				},
 				"optimist": {
 					"version": "0.6.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8",
-						"wordwrap": "0.0.3"
-					}
+					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+					"dev": true
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
-					}
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"dev": true
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+					"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
 					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-limit": "1.1.0"
-					}
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true
 				},
 				"parse-glob": {
 					"version": "3.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"glob-base": "0.3.0",
-						"is-dotfile": "1.0.3",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+					"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+					"dev": true
 				},
 				"parse-json": {
 					"version": "2.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"error-ex": "1.3.1"
-					}
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
 					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
 					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pinkie": "2.0.4"
-					}
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"dev": true
 				},
 				"pkg-dir": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 					"dev": true,
-					"requires": {
-						"find-up": "1.1.2"
-					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
-							}
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+							"dev": true
 						}
 					}
 				},
 				"preserve": {
 					"version": "0.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+					"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
 					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 					"dev": true
 				},
 				"randomatic": {
 					"version": "1.1.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+					"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 					"dev": true,
-					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
-					},
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+							"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 							"dev": true,
-							"requires": {
-								"kind-of": "3.2.2"
-							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"is-buffer": "1.1.5"
-									}
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true
 								}
 							}
 						},
 						"kind-of": {
 							"version": "4.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-buffer": "1.1.5"
-							}
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+							"dev": true
 						}
 					}
 				},
 				"read-pkg": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
-							}
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+							"dev": true
 						}
 					}
 				},
 				"regenerator-runtime": {
 					"version": "0.11.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+					"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
 					"dev": true
 				},
 				"regex-cache": {
 					"version": "0.4.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-equal-shallow": "0.1.3"
-					}
+					"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+					"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+					"dev": true
 				},
 				"remove-trailing-separator": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+					"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
 					"dev": true
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+					"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
 					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 					"dev": true
 				},
 				"repeating": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-finite": "1.0.2"
-					}
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+					"dev": true
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 					"dev": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
 					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+					"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
 					"dev": true,
-					"optional": true,
-					"requires": {
-						"align-text": "0.1.4"
-					}
+					"optional": true
 				},
 				"rimraf": {
 					"version": "2.6.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"glob": "7.1.2"
-					}
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+					"dev": true
 				},
 				"semver": {
 					"version": "5.4.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
 					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"shebang-regex": "1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"dev": true
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+					"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
 					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 					"dev": true
 				},
 				"spawn-wrap": {
 					"version": "1.3.8",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.0"
-					}
+					"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.8.tgz",
+					"integrity": "sha512-Yfkd7Yiwz4RcBPrDWzvhnTzQINBHNqOEhUzOdWZ67Y9b4wzs3Gz6ymuptQmRBpzlpOzroM7jwzmBdRec7JJ0UA==",
+					"dev": true
 				},
 				"spdx-correct": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"spdx-license-ids": "1.2.2"
-					}
+					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+					"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+					"dev": true
 				},
 				"spdx-expression-parse": {
 					"version": "1.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+					"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
 					"dev": true
 				},
 				"spdx-license-ids": {
 					"version": "1.2.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+					"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
 					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
-					},
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-regex": "3.0.0"
-							}
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true
 						}
 					}
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true
 				},
 				"strip-bom": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
 					"dev": true
 				},
 				"test-exclude": {
 					"version": "4.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "2.3.11",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
-					}
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+					"integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+					"dev": true
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
 					"dev": true
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
 					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
 					"dev": true,
 					"optional": true,
-					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
-					},
 					"dependencies": {
 						"yargs": {
 							"version": "3.10.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+							"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 							"dev": true,
-							"optional": true,
-							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
-								"window-size": "0.1.0"
-							}
+							"optional": true
 						}
 					}
 				},
 				"uglify-to-browserify": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+					"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
 					"dev": true,
 					"optional": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"spdx-correct": "1.0.2",
-						"spdx-expression-parse": "1.0.4"
-					}
+					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+					"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+					"dev": true
 				},
 				"which": {
 					"version": "1.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"isexe": "2.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+					"dev": true
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
 					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
 					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
-					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
-					},
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
-							}
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"dev": true
 						}
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
-					}
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+					"dev": true
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
 					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
 					"dev": true,
-					"requires": {
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "8.0.0"
-					},
 					"dependencies": {
 						"cliui": {
 							"version": "3.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 							"dev": true,
-							"requires": {
-								"string-width": "1.0.2",
-								"strip-ansi": "3.0.1",
-								"wrap-ansi": "2.1.0"
-							},
 							"dependencies": {
 								"string-width": {
 									"version": "1.0.2",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"code-point-at": "1.1.0",
-										"is-fullwidth-code-point": "1.0.0",
-										"strip-ansi": "3.0.1"
-									}
+									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+									"dev": true
 								}
 							}
 						}
@@ -7353,15 +5393,14 @@
 				},
 				"yargs-parser": {
 					"version": "8.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
 					"dev": true,
-					"requires": {
-						"camelcase": "4.1.0"
-					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 							"dev": true
 						}
 					}
@@ -7384,20 +5423,13 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
-			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
-			}
+			"dev": true
 		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
-			"requires": {
-				"wrappy": "1.0.2"
-			}
+			"dev": true
 		},
 		"onetime": {
 			"version": "1.1.0",
@@ -7416,10 +5448,6 @@
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
-			"requires": {
-				"minimist": "0.0.8",
-				"wordwrap": "0.0.3"
-			},
 			"dependencies": {
 				"wordwrap": {
 					"version": "0.0.3",
@@ -7433,27 +5461,13 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"dev": true,
-			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
-			}
+			"dev": true
 		},
 		"ora": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
 			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-spinners": "0.1.2",
-				"object-assign": "4.1.1"
-			}
+			"dev": true
 		},
 		"os-browserify": {
 			"version": "0.1.2",
@@ -7471,10 +5485,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-			"dev": true,
-			"requires": {
-				"lcid": "1.0.0"
-			}
+			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
@@ -7486,21 +5497,13 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
 			"integrity": "sha1-UM+GFjZeh+Ax4ppeyTOaPaRyX6I=",
-			"dev": true,
-			"requires": {
-				"shell-quote": "1.6.1"
-			}
+			"dev": true
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1"
-			}
+			"dev": true
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -7509,24 +5512,27 @@
 			"dev": true
 		},
 		"p-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 			"dev": true
 		},
 		"p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
-			"requires": {
-				"p-limit": "1.1.0"
-			}
+			"dev": true
 		},
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
 			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"dev": true
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 			"dev": true
 		},
 		"pako": {
@@ -7539,44 +5545,25 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
 			"integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
-			"dev": true,
-			"requires": {
-				"path-platform": "0.11.15"
-			}
+			"dev": true
 		},
 		"parse-asn1": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-			"dev": true,
-			"requires": {
-				"asn1.js": "4.9.2",
-				"browserify-aes": "1.1.1",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.3",
-				"pbkdf2": "3.0.14"
-			}
+			"dev": true
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
-			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
-			}
+			"dev": true
 		},
 		"parse-json": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"dev": true,
-			"requires": {
-				"error-ex": "1.3.1"
-			}
+			"dev": true
 		},
 		"path-browserify": {
 			"version": "0.0.0",
@@ -7625,9 +5612,6 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
 			"dev": true,
-			"requires": {
-				"isarray": "0.0.1"
-			},
 			"dependencies": {
 				"isarray": {
 					"version": "0.0.1",
@@ -7641,24 +5625,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
-			}
+			"dev": true
 		},
 		"pbkdf2": {
 			"version": "3.0.14",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
-			"requires": {
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.9"
-			}
+			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA=="
 		},
 		"pend": {
 			"version": "1.2.0",
@@ -7688,38 +5660,25 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
-			"requires": {
-				"pinkie": "2.0.4"
-			}
+			"dev": true
 		},
 		"pkg-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 			"dev": true,
-			"requires": {
-				"find-up": "1.1.2"
-			},
 			"dependencies": {
 				"find-up": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
-					}
+					"dev": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -7728,28 +5687,18 @@
 			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
 			"integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
 			"dev": true,
-			"requires": {
-				"find-up": "1.1.2"
-			},
 			"dependencies": {
 				"find-up": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
-					}
+					"dev": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -7762,24 +5711,13 @@
 		"popsicle": {
 			"version": "9.1.0",
 			"resolved": "https://registry.npmjs.org/popsicle/-/popsicle-9.1.0.tgz",
-			"integrity": "sha1-T5APONV6V07BcO2kBJbjZAgr/2Y=",
-			"requires": {
-				"concat-stream": "1.6.0",
-				"form-data": "2.3.1",
-				"make-error-cause": "1.2.2",
-				"tough-cookie": "2.3.3"
-			}
+			"integrity": "sha1-T5APONV6V07BcO2kBJbjZAgr/2Y="
 		},
 		"portfinder": {
 			"version": "1.0.13",
 			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
 			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
 			"dev": true,
-			"requires": {
-				"async": "1.5.2",
-				"debug": "2.6.9",
-				"mkdirp": "0.5.1"
-			},
 			"dependencies": {
 				"async": {
 					"version": "1.5.2",
@@ -7811,21 +5749,13 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
 			"integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-			"dev": true,
-			"requires": {
-				"get-stdin": "4.0.1",
-				"meow": "3.7.0"
-			}
+			"dev": true
 		},
 		"pretty-format": {
 			"version": "21.2.1",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
 			"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
 			"dev": true,
-			"requires": {
-				"ansi-regex": "3.0.0",
-				"ansi-styles": "3.2.0"
-			},
 			"dependencies": {
 				"ansi-regex": {
 					"version": "3.0.0",
@@ -7837,10 +5767,7 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
-					"requires": {
-						"color-convert": "1.9.1"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -7857,9 +5784,9 @@
 			"dev": true
 		},
 		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"progress": {
 			"version": "1.1.8",
@@ -7877,14 +5804,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
 			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-			"dev": true,
-			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"parse-asn1": "5.1.0",
-				"randombytes": "2.0.5"
-			}
+			"dev": true
 		},
 		"punycode": {
 			"version": "1.4.1",
@@ -7920,28 +5840,18 @@
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 			"dev": true,
-			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
-			},
 			"dependencies": {
 				"is-number": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2"
-					},
 					"dependencies": {
 						"kind-of": {
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
+							"dev": true
 						}
 					}
 				},
@@ -7949,117 +5859,69 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
+					"dev": true
 				}
 			}
 		},
 		"randombytes": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A=="
 		},
 		"randomfill": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
 			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
-			"dev": true,
-			"requires": {
-				"randombytes": "2.0.5",
-				"safe-buffer": "5.1.1"
-			}
+			"dev": true
 		},
 		"read-only-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
 			"integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "2.3.3"
-			}
+			"dev": true
 		},
 		"read-pkg": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-			"dev": true,
-			"requires": {
-				"load-json-file": "1.1.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "1.1.0"
-			}
+			"dev": true
 		},
 		"read-pkg-up": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
-			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
-			},
 			"dependencies": {
 				"find-up": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
-					}
+					"dev": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
+					"dev": true
 				}
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
-			}
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+			"integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ=="
 		},
 		"readdirp": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.3",
-				"set-immediate-shim": "1.0.1"
-			}
+			"dev": true
 		},
 		"redent": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-			"dev": true,
-			"requires": {
-				"indent-string": "2.1.0",
-				"strip-indent": "1.0.1"
-			}
+			"dev": true
 		},
 		"regenerate": {
 			"version": "1.3.3",
@@ -8068,41 +5930,27 @@
 			"dev": true
 		},
 		"regenerator-runtime": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-			"dev": true
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"private": "0.1.8"
-			}
+			"dev": true
 		},
 		"regex-cache": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"dev": true,
-			"requires": {
-				"is-equal-shallow": "0.1.3"
-			}
+			"dev": true
 		},
 		"regexpu-core": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-			"dev": true,
-			"requires": {
-				"regenerate": "1.3.3",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
-			}
+			"dev": true
 		},
 		"regjsgen": {
 			"version": "0.2.0",
@@ -8115,9 +5963,6 @@
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
-			"requires": {
-				"jsesc": "0.5.0"
-			},
 			"dependencies": {
 				"jsesc": {
 					"version": "0.5.0",
@@ -8149,49 +5994,19 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
-			"requires": {
-				"is-finite": "1.0.2"
-			}
+			"dev": true
 		},
 		"request": {
 			"version": "2.79.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
 			"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
 			"dev": true,
-			"requires": {
-				"aws-sign2": "0.6.0",
-				"aws4": "1.6.0",
-				"caseless": "0.11.0",
-				"combined-stream": "1.0.5",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.1.4",
-				"har-validator": "2.0.6",
-				"hawk": "3.1.3",
-				"http-signature": "1.1.1",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.17",
-				"oauth-sign": "0.8.2",
-				"qs": "6.3.2",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
-				"tunnel-agent": "0.4.3",
-				"uuid": "3.1.0"
-			},
 			"dependencies": {
 				"form-data": {
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
 					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-					"dev": true,
-					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.17"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -8199,10 +6014,7 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
 			"integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
-			"dev": true,
-			"requires": {
-				"throttleit": "0.0.2"
-			}
+			"dev": true
 		},
 		"require-from-string": {
 			"version": "1.2.1",
@@ -8220,11 +6032,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-			"dev": true,
-			"requires": {
-				"caller-path": "0.1.0",
-				"resolve-from": "1.0.1"
-			}
+			"dev": true
 		},
 		"requires-port": {
 			"version": "1.0.0",
@@ -8236,10 +6044,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
 			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-			"dev": true,
-			"requires": {
-				"path-parse": "1.0.5"
-			}
+			"dev": true
 		},
 		"resolve-from": {
 			"version": "1.0.1",
@@ -8252,9 +6057,6 @@
 			"resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-0.1.0.tgz",
 			"integrity": "sha1-AsyZNBDik2livZcWahsHfalyVTE=",
 			"dev": true,
-			"requires": {
-				"resolve-from": "2.0.0"
-			},
 			"dependencies": {
 				"resolve-from": {
 					"version": "2.0.0",
@@ -8268,11 +6070,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-			"dev": true,
-			"requires": {
-				"exit-hook": "1.1.1",
-				"onetime": "1.1.0"
-			}
+			"dev": true
 		},
 		"rewire": {
 			"version": "2.5.2",
@@ -8285,20 +6083,12 @@
 			"resolved": "https://registry.npmjs.org/rewireify/-/rewireify-0.2.5.tgz",
 			"integrity": "sha1-Gm8dQMQxEbP6ZO2fn2OZfDBZzog=",
 			"dev": true,
-			"requires": {
-				"minimatch": "2.0.10",
-				"rewire": "2.5.2",
-				"through": "2.3.8"
-			},
 			"dependencies": {
 				"minimatch": {
 					"version": "2.0.10",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "1.1.8"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -8311,20 +6101,13 @@
 		"ripemd160": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-			"requires": {
-				"hash-base": "2.0.2",
-				"inherits": "2.0.3"
-			}
+			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc="
 		},
 		"run-async": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
-			"requires": {
-				"is-promise": "2.1.0"
-			}
+			"dev": true
 		},
 		"rx-lite": {
 			"version": "4.0.8",
@@ -8336,19 +6119,13 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
-			"requires": {
-				"rx-lite": "4.0.8"
-			}
+			"dev": true
 		},
 		"rxjs": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
-			"integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
-			"dev": true,
-			"requires": {
-				"symbol-observable": "1.0.4"
-			}
+			"version": "5.5.6",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+			"integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+			"dev": true
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
@@ -8362,9 +6139,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
 			"dev": true
 		},
 		"set-immediate-shim": {
@@ -8374,32 +6151,21 @@
 			"dev": true
 		},
 		"sha.js": {
-			"version": "2.4.9",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
-			"integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
-			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
-			}
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+			"integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA=="
 		},
 		"shasum": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
 			"integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
 			"dev": true,
-			"requires": {
-				"json-stable-stringify": "0.0.1",
-				"sha.js": "2.4.9"
-			},
 			"dependencies": {
 				"json-stable-stringify": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
 					"integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
-					"dev": true,
-					"requires": {
-						"jsonify": "0.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -8407,10 +6173,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
-			"requires": {
-				"shebang-regex": "1.0.0"
-			}
+			"dev": true
 		},
 		"shebang-regex": {
 			"version": "1.0.0",
@@ -8422,45 +6185,25 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
 			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-			"dev": true,
-			"requires": {
-				"array-filter": "0.0.1",
-				"array-map": "0.0.0",
-				"array-reduce": "0.0.0",
-				"jsonify": "0.0.0"
-			}
+			"dev": true
 		},
 		"should": {
 			"version": "11.2.1",
 			"resolved": "https://registry.npmjs.org/should/-/should-11.2.1.tgz",
 			"integrity": "sha1-kPVRRVUtAc/CAGZuToGKHJZw7aI=",
-			"dev": true,
-			"requires": {
-				"should-equal": "1.0.1",
-				"should-format": "3.0.3",
-				"should-type": "1.4.0",
-				"should-type-adaptors": "1.0.1",
-				"should-util": "1.0.0"
-			}
+			"dev": true
 		},
 		"should-equal": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
 			"integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
-			"dev": true,
-			"requires": {
-				"should-type": "1.4.0"
-			}
+			"dev": true
 		},
 		"should-format": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
 			"integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
-			"dev": true,
-			"requires": {
-				"should-type": "1.4.0",
-				"should-type-adaptors": "1.0.1"
-			}
+			"dev": true
 		},
 		"should-sinon": {
 			"version": "0.0.6",
@@ -8475,14 +6218,10 @@
 			"dev": true
 		},
 		"should-type-adaptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.0.1.tgz",
-			"integrity": "sha1-7+VVPN9oz/ZuXF9RtxLcNRx3vqo=",
-			"dev": true,
-			"requires": {
-				"should-type": "1.4.0",
-				"should-util": "1.0.0"
-			}
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+			"integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+			"dev": true
 		},
 		"should-util": {
 			"version": "1.0.0",
@@ -8500,17 +6239,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-2.2.0.tgz",
 			"integrity": "sha1-OxtC/13vy/UaUqYqym1hFxuf0mI=",
-			"dev": true,
-			"requires": {
-				"diff": "3.2.0",
-				"formatio": "1.2.0",
-				"lolex": "1.6.0",
-				"native-promise-only": "0.8.1",
-				"path-to-regexp": "1.7.0",
-				"samsam": "1.3.0",
-				"text-encoding": "0.6.4",
-				"type-detect": "4.0.5"
-			}
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
@@ -8528,10 +6257,7 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-			"dev": true,
-			"requires": {
-				"hoek": "2.16.3"
-			}
+			"dev": true
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -8543,19 +6269,13 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-			"dev": true,
-			"requires": {
-				"source-map": "0.5.7"
-			}
+			"dev": true
 		},
 		"spdx-correct": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-			"dev": true,
-			"requires": {
-				"spdx-license-ids": "1.2.2"
-			}
+			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "1.0.4",
@@ -8580,16 +6300,6 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
 			"dev": true,
-			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
-			},
 			"dependencies": {
 				"assert-plus": {
 					"version": "1.0.0",
@@ -8609,44 +6319,25 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-			"dev": true,
-			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
-			}
+			"dev": true
 		},
 		"stream-combiner2": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
 			"integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-			"dev": true,
-			"requires": {
-				"duplexer2": "0.1.4",
-				"readable-stream": "2.3.3"
-			}
+			"dev": true
 		},
 		"stream-http": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
-			"dev": true,
-			"requires": {
-				"builtin-status-codes": "3.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"to-arraybuffer": "1.0.1",
-				"xtend": "4.0.1"
-			}
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
+			"integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
+			"dev": true
 		},
 		"stream-splicer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
 			"integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
-			"dev": true,
-			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
-			}
+			"dev": true
 		},
 		"stream-to-observable": {
 			"version": "0.1.0",
@@ -8654,35 +6345,22 @@
 			"integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
 			"dev": true
 		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+		},
 		"string-width": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"dev": true,
-			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"strip-ansi": "3.0.1"
-			}
-		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
+			"dev": true
 		},
 		"stringify-object": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
-			"integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
-			"dev": true,
-			"requires": {
-				"get-own-enumerable-property-symbols": "2.0.1",
-				"is-obj": "1.0.1",
-				"is-regexp": "1.0.0"
-			}
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+			"integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+			"dev": true
 		},
 		"stringstream": {
 			"version": "0.0.5",
@@ -8694,19 +6372,13 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "2.1.1"
-			}
+			"dev": true
 		},
 		"strip-bom": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"dev": true,
-			"requires": {
-				"is-utf8": "0.2.1"
-			}
+			"dev": true
 		},
 		"strip-eof": {
 			"version": "1.0.0",
@@ -8718,10 +6390,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"dev": true,
-			"requires": {
-				"get-stdin": "4.0.1"
-			}
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
@@ -8734,9 +6403,6 @@
 			"resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
 			"integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
 			"dev": true,
-			"requires": {
-				"minimist": "1.2.0"
-			},
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
@@ -8753,45 +6419,28 @@
 			"dev": true
 		},
 		"symbol-observable": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-			"integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
 			"dev": true
 		},
 		"syntax-error": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
-			"integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
-			"dev": true,
-			"requires": {
-				"acorn": "4.0.13"
-			}
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+			"integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+			"dev": true
 		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
-			"requires": {
-				"ajv": "5.3.0",
-				"ajv-keywords": "2.1.1",
-				"chalk": "2.3.0",
-				"lodash": "4.17.4",
-				"slice-ansi": "1.0.0",
-				"string-width": "2.1.1"
-			},
 			"dependencies": {
 				"ajv": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-					"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
-					"dev": true,
-					"requires": {
-						"co": "4.6.0",
-						"fast-deep-equal": "1.0.0",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.3.1"
-					}
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "3.0.0",
@@ -8803,21 +6452,19 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
-					"requires": {
-						"color-convert": "1.9.1"
-					}
+					"dev": true
 				},
 				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
-					}
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
@@ -8829,53 +6476,33 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 					"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "2.0.0"
-					}
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
-					}
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "3.0.0"
-					}
+					"dev": true
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
-					"requires": {
-						"has-flag": "2.0.0"
-					}
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true
 				}
 			}
 		},
 		"test-exclude": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-			"integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
-			"dev": true,
-			"requires": {
-				"arrify": "1.0.1",
-				"micromatch": "2.3.11",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"require-main-filename": "1.0.1"
-			}
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.0.tgz",
+			"integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
+			"dev": true
 		},
 		"text-encoding": {
 			"version": "0.6.4",
@@ -8905,29 +6532,19 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "2.3.3",
-				"xtend": "4.0.1"
-			}
+			"dev": true
 		},
 		"timers-browserify": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
 			"integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
-			"dev": true,
-			"requires": {
-				"process": "0.11.10"
-			}
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.31",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
 			"integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-			"dev": true,
-			"requires": {
-				"os-tmpdir": "1.0.2"
-			}
+			"dev": true
 		},
 		"to-arraybuffer": {
 			"version": "1.0.1",
@@ -8944,10 +6561,7 @@
 		"tough-cookie": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-			"requires": {
-				"punycode": "1.4.1"
-			}
+			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE="
 		},
 		"trim-newlines": {
 			"version": "1.0.0",
@@ -8961,16 +6575,10 @@
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
 			"dev": true
 		},
-		"tryit": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-			"dev": true
-		},
 		"tty-browserify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+			"integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
 			"dev": true
 		},
 		"tunnel-agent": {
@@ -8988,15 +6596,12 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
-			"requires": {
-				"prelude-ls": "1.1.2"
-			}
+			"dev": true
 		},
 		"type-detect": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-			"integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
 		"typedarray": {
@@ -9009,9 +6614,13 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.28.tgz",
 			"integrity": "sha512-0h/qGay016GG2lVav3Kz174F3T2Vjlz2v6HCt+WDQpoXfco0hWwF5gHK9yh88mUYvIC+N7Z8NT8WpjSp1yoqGA==",
 			"dev": true,
-			"requires": {
-				"commander": "2.11.0",
-				"source-map": "0.5.7"
+			"dependencies": {
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"dev": true
+				}
 			}
 		},
 		"umd": {
@@ -9031,9 +6640,6 @@
 			"resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
 			"integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
 			"dev": true,
-			"requires": {
-				"qs": "2.3.3"
-			},
 			"dependencies": {
 				"qs": {
 					"version": "2.3.3",
@@ -9065,10 +6671,6 @@
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
 			"dev": true,
-			"requires": {
-				"punycode": "1.3.2",
-				"querystring": "0.2.0"
-			},
 			"dependencies": {
 				"punycode": {
 					"version": "1.3.2",
@@ -9079,9 +6681,9 @@
 			}
 		},
 		"url-join": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.2.tgz",
-			"integrity": "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc=",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+			"integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
 			"dev": true
 		},
 		"user-home": {
@@ -9095,9 +6697,6 @@
 			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
 			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
 			"dev": true,
-			"requires": {
-				"inherits": "2.0.1"
-			},
 			"dependencies": {
 				"inherits": {
 					"version": "2.0.1",
@@ -9113,40 +6712,28 @@
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"uuid": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
 			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-			"dev": true,
-			"requires": {
-				"user-home": "1.1.1"
-			}
+			"dev": true
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-			"dev": true,
-			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
-			}
+			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
-			"requires": {
-				"assert-plus": "1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
-			},
 			"dependencies": {
 				"assert-plus": {
 					"version": "1.0.0",
@@ -9160,124 +6747,49 @@
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
 			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-			"dev": true,
-			"requires": {
-				"indexof": "0.0.1"
-			}
+			"dev": true
 		},
 		"watchify": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/watchify/-/watchify-3.9.0.tgz",
-			"integrity": "sha1-8HX9LoqGrN6Eztum5cKgvt1SPZ4=",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/watchify/-/watchify-3.10.0.tgz",
+			"integrity": "sha512-SRSumWalHAxciSaEtua1HFqB8L+et5ieHjJRuNssqj4qXz4pJoR6cAeFWni3reXyOY3cVE6b55sJ8WYR43abBQ==",
 			"dev": true,
-			"requires": {
-				"anymatch": "1.3.2",
-				"browserify": "14.5.0",
-				"chokidar": "1.7.0",
-				"defined": "1.0.0",
-				"outpipe": "1.1.1",
-				"through2": "2.0.3",
-				"xtend": "4.0.1"
-			},
 			"dependencies": {
+				"acorn": {
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+					"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+					"dev": true
+				},
 				"browserify": {
-					"version": "14.5.0",
-					"resolved": "https://registry.npmjs.org/browserify/-/browserify-14.5.0.tgz",
-					"integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
-					"dev": true,
-					"requires": {
-						"JSONStream": "1.3.1",
-						"assert": "1.4.1",
-						"browser-pack": "6.0.2",
-						"browser-resolve": "1.11.2",
-						"browserify-zlib": "0.2.0",
-						"buffer": "5.0.8",
-						"cached-path-relative": "1.0.1",
-						"concat-stream": "1.5.2",
-						"console-browserify": "1.1.0",
-						"constants-browserify": "1.0.0",
-						"crypto-browserify": "3.12.0",
-						"defined": "1.0.0",
-						"deps-sort": "2.0.0",
-						"domain-browser": "1.1.7",
-						"duplexer2": "0.1.4",
-						"events": "1.1.1",
-						"glob": "7.1.2",
-						"has": "1.0.1",
-						"htmlescape": "1.1.1",
-						"https-browserify": "1.0.0",
-						"inherits": "2.0.3",
-						"insert-module-globals": "7.0.1",
-						"labeled-stream-splicer": "2.0.0",
-						"module-deps": "4.1.1",
-						"os-browserify": "0.3.0",
-						"parents": "1.0.1",
-						"path-browserify": "0.0.0",
-						"process": "0.11.10",
-						"punycode": "1.4.1",
-						"querystring-es3": "0.2.1",
-						"read-only-stream": "2.0.0",
-						"readable-stream": "2.3.3",
-						"resolve": "1.5.0",
-						"shasum": "1.0.2",
-						"shell-quote": "1.6.1",
-						"stream-browserify": "2.0.1",
-						"stream-http": "2.7.2",
-						"string_decoder": "1.0.3",
-						"subarg": "1.0.0",
-						"syntax-error": "1.3.0",
-						"through2": "2.0.3",
-						"timers-browserify": "1.4.2",
-						"tty-browserify": "0.0.0",
-						"url": "0.11.0",
-						"util": "0.10.3",
-						"vm-browserify": "0.0.4",
-						"xtend": "4.0.1"
-					}
+					"version": "15.2.0",
+					"resolved": "https://registry.npmjs.org/browserify/-/browserify-15.2.0.tgz",
+					"integrity": "sha512-IHYyFPm2XjJCL+VV0ZtFv8wn/sAHVOm83q3yfSn8YWbZ9jcybgPKxSDdiuMU+35jUL1914l74RnXXPD9Iyo9yg==",
+					"dev": true
 				},
 				"browserify-zlib": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
 					"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-					"dev": true,
-					"requires": {
-						"pako": "1.0.6"
-					}
+					"dev": true
 				},
 				"buffer": {
 					"version": "5.0.8",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
 					"integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
-					"dev": true,
-					"requires": {
-						"base64-js": "1.2.1",
-						"ieee754": "1.1.8"
-					}
+					"dev": true
 				},
 				"concat-stream": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
 					"integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
 					"dev": true,
-					"requires": {
-						"inherits": "2.0.3",
-						"readable-stream": "2.0.6",
-						"typedarray": "0.0.6"
-					},
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.0.6",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
 							"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-							"dev": true,
-							"requires": {
-								"core-util-is": "1.0.2",
-								"inherits": "2.0.3",
-								"isarray": "1.0.0",
-								"process-nextick-args": "1.0.7",
-								"string_decoder": "0.10.31",
-								"util-deprecate": "1.0.2"
-							}
+							"dev": true
 						},
 						"string_decoder": {
 							"version": "0.10.31",
@@ -9287,11 +6799,31 @@
 						}
 					}
 				},
+				"detective": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/detective/-/detective-5.0.2.tgz",
+					"integrity": "sha512-NUsLoezj4wb9o7vpxS9F3L5vcO87ceyRBcl48op06YFNwkyIEY997JpSCA5lDlDuDc6JxOtaL5qfK3muoWxpMA==",
+					"dev": true
+				},
 				"https-browserify": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 					"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
 					"dev": true
+				},
+				"module-deps": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/module-deps/-/module-deps-5.0.1.tgz",
+					"integrity": "sha512-sigq/hm/L+Z5IGi1DDl0x2ptkw7S86aFh213QhPLD8v9Opv90IHzKIuWJrRa5bJ77DVKHco2CfIEuThcT/vDJA==",
+					"dev": true,
+					"dependencies": {
+						"concat-stream": {
+							"version": "1.6.0",
+							"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+							"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+							"dev": true
+						}
+					}
 				},
 				"os-browserify": {
 					"version": "0.3.0",
@@ -9304,6 +6836,12 @@
 					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
 					"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
 					"dev": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+					"dev": true
 				}
 			}
 		},
@@ -9311,10 +6849,7 @@
 			"version": "1.2.14",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
 			"integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-			"dev": true,
-			"requires": {
-				"isexe": "2.0.0"
-			}
+			"dev": true
 		},
 		"window-size": {
 			"version": "0.1.4",
@@ -9332,11 +6867,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
-			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
-			}
+			"dev": true
 		},
 		"wrappy": {
 			"version": "1.0.2",
@@ -9348,10 +6879,7 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-			"dev": true,
-			"requires": {
-				"mkdirp": "0.5.1"
-			}
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.1",
@@ -9375,26 +6903,13 @@
 			"version": "3.32.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
 			"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-			"dev": true,
-			"requires": {
-				"camelcase": "2.1.1",
-				"cliui": "3.2.0",
-				"decamelize": "1.2.0",
-				"os-locale": "1.4.0",
-				"string-width": "1.0.2",
-				"window-size": "0.1.4",
-				"y18n": "3.2.1"
-			}
+			"dev": true
 		},
 		"yauzl": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
 			"integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
-			"dev": true,
-			"requires": {
-				"buffer-crc32": "0.2.13",
-				"fd-slicer": "1.0.1"
-			}
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "JavaScript library for sending Lisk transactions from the client or server",
 	"main": "./dist-node/index.js",
 	"engines": {
-		"node": ">=6 <=9",
+		"node": ">=6.3 <=9",
 		"npm": ">=3 <=5"
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "JavaScript library for sending Lisk transactions from the client or server",
 	"main": "./dist-node/index.js",
 	"engines": {
-		"node": ">=6.3 <=9",
+		"node": ">=6.3 <=9.5",
 		"npm": ">=3 <=5"
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
 	"version": "0.4.5",
 	"description": "JavaScript library for sending Lisk transactions from the client or server",
 	"main": "./dist-node/index.js",
+	"engines": {
+		"node": ">=6 <=9",
+		"npm": "=>3 <=5"
+	},
 	"scripts": {
 		"prestart": "./bin/prestart.sh",
 		"start": "./bin/start.sh",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "./dist-node/index.js",
 	"engines": {
 		"node": ">=6 <=9",
-		"npm": "=>3 <=5"
+		"npm": ">=3 <=5"
 	},
 	"scripts": {
 		"prestart": "./bin/prestart.sh",

--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -27,7 +27,7 @@ export const bufferToHex = buffer => naclInstance.to_hex(buffer);
 const hexRegex = /^[0-9a-f]+/i;
 export const hexToBuffer = hex => {
 	if (typeof hex !== 'string') {
-		throw new TypeError('Argument must be a string');
+		throw new TypeError('Argument must be a string.');
 	}
 	const matchedHex = (hex.match(hexRegex) || [])[0];
 	if (!matchedHex) {

--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -24,17 +24,17 @@ export const bufferToBigNumberString = bigNumberBuffer =>
 
 export const bufferToHex = buffer => naclInstance.to_hex(buffer);
 
-const hexRegex = /^([0-9]|[a-f])+/gi;
+const hexRegex = /^[0-9a-f]+/i;
 export const hexToBuffer = hex => {
 	if (typeof hex !== 'string') {
-		throw new TypeError('argument must be string');
+		throw new TypeError('Argument must be a string');
 	}
-	const matchedHex = hex.match(hexRegex) || [];
-	if (matchedHex.length === 0) {
+	const matchedHex = (hex.match(hexRegex) || [])[0];
+	if (!matchedHex) {
 		return Buffer.alloc(0);
 	}
-	const evenLength = Math.floor(matchedHex[0].length / 2) * 2;
-	return Buffer.from(matchedHex[0].slice(0, evenLength), 'hex');
+	const evenLength = Math.floor(matchedHex.length / 2) * 2;
+	return Buffer.from(matchedHex.slice(0, evenLength), 'hex');
 };
 
 export const getFirstEightBytesReversed = publicKeyBytes =>

--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -24,17 +24,17 @@ export const bufferToBigNumberString = bigNumberBuffer =>
 
 export const bufferToHex = buffer => naclInstance.to_hex(buffer);
 
-const hexRegex = /([0-9]|[a-f])/gim;
+const hexRegex = /^([0-9]|[a-f])+/gi;
 export const hexToBuffer = hex => {
 	if (typeof hex !== 'string') {
-		return Buffer.alloc(0);
+		throw new TypeError('argument must be string');
 	}
 	const matchedHex = hex.match(hexRegex) || [];
 	if (matchedHex.length === 0) {
 		return Buffer.alloc(0);
 	}
-	const evenLength = Math.floor(matchedHex.length / 2) * 2;
-	return Buffer.from(matchedHex.slice(0, evenLength).join(''), 'hex');
+	const evenLength = Math.floor(matchedHex[0].length / 2) * 2;
+	return Buffer.from(matchedHex[0].slice(0, evenLength), 'hex');
 };
 
 export const getFirstEightBytesReversed = publicKeyBytes =>

--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -24,7 +24,18 @@ export const bufferToBigNumberString = bigNumberBuffer =>
 
 export const bufferToHex = buffer => naclInstance.to_hex(buffer);
 
-export const hexToBuffer = hex => Buffer.from(hex, 'hex');
+const hexRegex = /([0-9]|[a-f])/gim;
+export const hexToBuffer = hex => {
+	if (typeof hex !== 'string') {
+		return Buffer.alloc(0);
+	}
+	const matchedHex = hex.match(hexRegex) || [];
+	if (matchedHex.length === 0) {
+		return Buffer.alloc(0);
+	}
+	const evenLength = Math.floor(matchedHex.length / 2) * 2;
+	return Buffer.from(matchedHex.slice(0, evenLength).join(''), 'hex');
+};
 
 export const getFirstEightBytesReversed = publicKeyBytes =>
 	Buffer.from(publicKeyBytes)

--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -30,11 +30,13 @@ export const hexToBuffer = hex => {
 		throw new TypeError('Argument must be a string.');
 	}
 	const matchedHex = (hex.match(hexRegex) || [])[0];
-	if (!matchedHex) {
-		return Buffer.alloc(0);
+	if (!matchedHex || matchedHex.length !== hex.length) {
+		throw new TypeError('Argument must be a valid hex string.');
 	}
-	const evenLength = Math.floor(matchedHex.length / 2) * 2;
-	return Buffer.from(matchedHex.slice(0, evenLength), 'hex');
+	if (matchedHex.length % 2 !== 0) {
+		throw new TypeError('Argument must have a valid length of hex string.');
+	}
+	return Buffer.from(matchedHex, 'hex');
 };
 
 export const getFirstEightBytesReversed = publicKeyBytes =>

--- a/src/cryptography/encrypt.js
+++ b/src/cryptography/encrypt.js
@@ -125,9 +125,6 @@ const encryptAES256GCMWithPassword = (plainText, password) => {
 
 const getTagBuffer = tag => {
 	const tagBuffer = hexToBuffer(tag);
-	if (bufferToHex(tagBuffer) !== tag) {
-		throw new Error('Tag must be a hex string.');
-	}
 	if (tagBuffer.length !== 16) {
 		throw new Error('Tag must be 16 bytes.');
 	}

--- a/src/transactions/utils/getTransactionBytes.js
+++ b/src/transactions/utils/getTransactionBytes.js
@@ -49,7 +49,7 @@ export const getAssetDataForRegisterSecondSignatureTransaction = ({
 }) => {
 	checkRequiredFields(['publicKey'], signature);
 	const { publicKey } = signature;
-	return Buffer.from(publicKey, 'hex');
+	return cryptoModule.hexToBuffer(publicKey);
 };
 
 export const getAssetDataForRegisterDelegateTransaction = ({ delegate }) => {
@@ -159,13 +159,12 @@ const getTransactionBytes = transaction => {
 		BYTESIZES.TIMESTAMP,
 	);
 
-	const transactionSenderPublicKey = Buffer.from(
+	const transactionSenderPublicKey = cryptoModule.hexToBuffer(
 		transaction.senderPublicKey,
-		'hex',
 	);
-	const transactionRequesterPublicKey = transaction.requesterPublicKey
-		? Buffer.from(transaction.requesterPublicKey, 'hex')
-		: Buffer.alloc(0);
+	const transactionRequesterPublicKey = cryptoModule.hexToBuffer(
+		transaction.requesterPublicKey,
+	);
 
 	const transactionRecipientID = transaction.recipientId
 		? cryptography.bigNumberToBuffer(
@@ -185,9 +184,9 @@ const getTransactionBytes = transaction => {
 		? Buffer.from(transaction.signature, 'hex')
 		: Buffer.alloc(0);
 
-	const transactionSecondSignature = transaction.signSignature
-		? Buffer.from(transaction.signSignature, 'hex')
-		: Buffer.alloc(0);
+	const transactionSecondSignature = cryptoModule.hexToBuffer(
+		transaction.signSignature,
+	);
 
 	return Buffer.concat([
 		transactionType,

--- a/src/transactions/utils/getTransactionBytes.js
+++ b/src/transactions/utils/getTransactionBytes.js
@@ -49,7 +49,7 @@ export const getAssetDataForRegisterSecondSignatureTransaction = ({
 }) => {
 	checkRequiredFields(['publicKey'], signature);
 	const { publicKey } = signature;
-	return cryptoModule.hexToBuffer(publicKey);
+	return cryptography.hexToBuffer(publicKey);
 };
 
 export const getAssetDataForRegisterDelegateTransaction = ({ delegate }) => {
@@ -159,12 +159,12 @@ const getTransactionBytes = transaction => {
 		BYTESIZES.TIMESTAMP,
 	);
 
-	const transactionSenderPublicKey = cryptoModule.hexToBuffer(
+	const transactionSenderPublicKey = cryptography.hexToBuffer(
 		transaction.senderPublicKey,
 	);
 
 	const transactionRequesterPublicKey = transaction.requesterPublicKey
-		? cryptoModule.hexToBuffer(transaction.requesterPublicKey)
+		? cryptography.hexToBuffer(transaction.requesterPublicKey)
 		: Buffer.alloc(0);
 
 	const transactionRecipientID = transaction.recipientId
@@ -182,11 +182,11 @@ const getTransactionBytes = transaction => {
 	const transactionAssetData = getAssetBytes(transaction);
 
 	const transactionSignature = transaction.signature
-		? cryptoModule.hexToBuffer(transaction.signature)
+		? cryptography.hexToBuffer(transaction.signature)
 		: Buffer.alloc(0);
 
 	const transactionSecondSignature = transaction.signSignature
-		? cryptoModule.hexToBuffer(transaction.signSignature)
+		? cryptography.hexToBuffer(transaction.signSignature)
 		: Buffer.alloc(0);
 
 	return Buffer.concat([

--- a/src/transactions/utils/getTransactionBytes.js
+++ b/src/transactions/utils/getTransactionBytes.js
@@ -162,9 +162,10 @@ const getTransactionBytes = transaction => {
 	const transactionSenderPublicKey = cryptoModule.hexToBuffer(
 		transaction.senderPublicKey,
 	);
-	const transactionRequesterPublicKey = cryptoModule.hexToBuffer(
-		transaction.requesterPublicKey,
-	);
+
+	const transactionRequesterPublicKey = transaction.requesterPublicKey
+		? cryptoModule.hexToBuffer(transaction.requesterPublicKey)
+		: Buffer.alloc(0);
 
 	const transactionRecipientID = transaction.recipientId
 		? cryptography.bigNumberToBuffer(
@@ -181,12 +182,12 @@ const getTransactionBytes = transaction => {
 	const transactionAssetData = getAssetBytes(transaction);
 
 	const transactionSignature = transaction.signature
-		? Buffer.from(transaction.signature, 'hex')
+		? cryptoModule.hexToBuffer(transaction.signature)
 		: Buffer.alloc(0);
 
-	const transactionSecondSignature = cryptoModule.hexToBuffer(
-		transaction.signSignature,
-	);
+	const transactionSecondSignature = transaction.signSignature
+		? cryptoModule.hexToBuffer(transaction.signSignature)
+		: Buffer.alloc(0);
 
 	return Buffer.concat([
 		transactionType,

--- a/src/transactions/utils/validation.js
+++ b/src/transactions/utils/validation.js
@@ -13,20 +13,16 @@
  *
  */
 import bignum from 'browserify-bignum';
-import { bufferToHex, hexToBuffer } from 'cryptography/convert';
+import { hexToBuffer } from 'cryptography/convert';
 import { MAX_ADDRESS_NUMBER } from 'constants';
 
 export const validatePublicKey = publicKey => {
 	const publicKeyBuffer = hexToBuffer(publicKey);
-	if (bufferToHex(publicKeyBuffer) !== publicKey) {
-		throw new Error('Public key must be a valid hex string.');
-	}
 	if (publicKeyBuffer.length !== 32) {
 		throw new Error(
 			`Public key ${publicKey} length differs from the expected 32 bytes for a public key.`,
 		);
 	}
-
 	return true;
 };
 

--- a/test/cryptography/convert.js
+++ b/test/cryptography/convert.js
@@ -65,6 +65,22 @@ describe('convert', () => {
 			const buffer = hexToBuffer(defaultHex);
 			return buffer.should.be.eql(defaultBuffer);
 		});
+		it('should create empty Buffer from non-string', () => {
+			const buffer = hexToBuffer(123);
+			return buffer.should.be.eql(Buffer.alloc(0));
+		});
+		it('should create empty Buffer from non hex string', () => {
+			const buffer = hexToBuffer('yKJh');
+			return buffer.should.be.eql(Buffer.alloc(0));
+		});
+		it('should create partial Buffer from partially non hex string', () => {
+			const buffer = hexToBuffer('Abxzzzz');
+			return buffer.should.be.eql(Buffer.from('Ab', 'hex'));
+		});
+		it('should create even numbered Buffer from odd number hex string', () => {
+			const buffer = hexToBuffer('c3a5c3a4c3b6a');
+			return buffer.should.be.eql(Buffer.from('c3a5c3a4c3b6', 'hex'));
+		});
 	});
 
 	describe('#getFirstEightBytesReversed', () => {

--- a/test/cryptography/convert.js
+++ b/test/cryptography/convert.js
@@ -65,9 +65,15 @@ describe('convert', () => {
 			const buffer = hexToBuffer(defaultHex);
 			return buffer.should.be.eql(defaultBuffer);
 		});
-		it('should create empty Buffer from non-string', () => {
-			const buffer = hexToBuffer(123);
-			return buffer.should.be.eql(Buffer.alloc(0));
+		it('should throw TypeError with number', () => {
+			return (() => hexToBuffer(123)).should.throw(
+				new TypeError('argument must be string'),
+			);
+		});
+		it('should throw TypeError with object', () => {
+			return (() => hexToBuffer({})).should.throw(
+				new TypeError('argument must be string'),
+			);
 		});
 		it('should create empty Buffer from non hex string', () => {
 			const buffer = hexToBuffer('yKJh');
@@ -75,6 +81,10 @@ describe('convert', () => {
 		});
 		it('should create partial Buffer from partially non hex string', () => {
 			const buffer = hexToBuffer('Abxzzzz');
+			return buffer.should.be.eql(Buffer.from('Ab', 'hex'));
+		});
+		it('should create partial Buffer with only first valid hex string', () => {
+			const buffer = hexToBuffer('Abxzzab');
 			return buffer.should.be.eql(Buffer.from('Ab', 'hex'));
 		});
 		it('should create even numbered Buffer from odd number hex string', () => {

--- a/test/cryptography/convert.js
+++ b/test/cryptography/convert.js
@@ -87,6 +87,10 @@ describe('convert', () => {
 			const buffer = hexToBuffer('Abxzzab');
 			return buffer.should.be.eql(Buffer.from('Ab', 'hex'));
 		});
+		it('should create even numbered Buffer from odd number hex string with invalid hex', () => {
+			const buffer = hexToBuffer('123xxxx');
+			return buffer.should.be.eql(Buffer.from('12', 'hex'));
+		});
 		it('should create even numbered Buffer from odd number hex string', () => {
 			const buffer = hexToBuffer('c3a5c3a4c3b6a');
 			return buffer.should.be.eql(Buffer.from('c3a5c3a4c3b6', 'hex'));

--- a/test/cryptography/convert.js
+++ b/test/cryptography/convert.js
@@ -65,32 +65,39 @@ describe('convert', () => {
 			const buffer = hexToBuffer(defaultHex);
 			return buffer.should.be.eql(defaultBuffer);
 		});
+
 		it('should throw TypeError with number', () => {
-			return (() => hexToBuffer(123)).should.throw(
-				new TypeError('argument must be string'),
-			);
+			return hexToBuffer
+				.bind(null, 123)
+				.should.throw(TypeError, { message: 'Argument must be a string.' });
 		});
+
 		it('should throw TypeError with object', () => {
-			return (() => hexToBuffer({})).should.throw(
-				new TypeError('argument must be string'),
-			);
+			return hexToBuffer
+				.bind(null, {})
+				.should.throw(TypeError, { message: 'Argument must be a string.' });
 		});
+
 		it('should create empty Buffer from non hex string', () => {
 			const buffer = hexToBuffer('yKJh');
 			return buffer.should.be.eql(Buffer.alloc(0));
 		});
+
 		it('should create partial Buffer from partially non hex string', () => {
 			const buffer = hexToBuffer('Abxzzzz');
 			return buffer.should.be.eql(Buffer.from('Ab', 'hex'));
 		});
+
 		it('should create partial Buffer with only first valid hex string', () => {
 			const buffer = hexToBuffer('Abxzzab');
 			return buffer.should.be.eql(Buffer.from('Ab', 'hex'));
 		});
+
 		it('should create even numbered Buffer from odd number hex string with invalid hex', () => {
 			const buffer = hexToBuffer('123xxxx');
 			return buffer.should.be.eql(Buffer.from('12', 'hex'));
 		});
+
 		it('should create even numbered Buffer from odd number hex string', () => {
 			const buffer = hexToBuffer('c3a5c3a4c3b6a');
 			return buffer.should.be.eql(Buffer.from('c3a5c3a4c3b6', 'hex'));

--- a/test/cryptography/convert.js
+++ b/test/cryptography/convert.js
@@ -78,29 +78,34 @@ describe('convert', () => {
 				.should.throw(TypeError, { message: 'Argument must be a string.' });
 		});
 
-		it('should create empty Buffer from non hex string', () => {
-			const buffer = hexToBuffer('yKJh');
-			return buffer.should.be.eql(Buffer.alloc(0));
+		it('should throw TypeError with non hex string', () => {
+			return hexToBuffer.bind(null, 'yKJj').should.throw(TypeError, {
+				message: 'Argument must be a valid hex string.',
+			});
 		});
 
-		it('should create partial Buffer from partially non hex string', () => {
-			const buffer = hexToBuffer('Abxzzzz');
-			return buffer.should.be.eql(Buffer.from('Ab', 'hex'));
+		it('should throw TypeError with partially correct hex string', () => {
+			return hexToBuffer.bind(null, 'Abxzzzz').should.throw(TypeError, {
+				message: 'Argument must be a valid hex string.',
+			});
 		});
 
-		it('should create partial Buffer with only first valid hex string', () => {
-			const buffer = hexToBuffer('Abxzzab');
-			return buffer.should.be.eql(Buffer.from('Ab', 'hex'));
+		it('should throw TypeError with odd number of string with partially correct hex string', () => {
+			return hexToBuffer.bind(null, 'Abxzzab').should.throw(TypeError, {
+				message: 'Argument must be a valid hex string.',
+			});
 		});
 
-		it('should create even numbered Buffer from odd number hex string with invalid hex', () => {
-			const buffer = hexToBuffer('123xxxx');
-			return buffer.should.be.eql(Buffer.from('12', 'hex'));
+		it('should throw TypeError with odd number hex string with invalid hex', () => {
+			return hexToBuffer.bind(null, '123xxxx').should.throw(TypeError, {
+				message: 'Argument must be a valid hex string.',
+			});
 		});
 
-		it('should create even numbered Buffer from odd number hex string', () => {
-			const buffer = hexToBuffer('c3a5c3a4c3b6a');
-			return buffer.should.be.eql(Buffer.from('c3a5c3a4c3b6', 'hex'));
+		it('should throw TypeError with odd number of hex string', () => {
+			return hexToBuffer.bind(null, 'c3a5c3a4c3b6a').should.throw(TypeError, {
+				message: 'Argument must have a valid length of hex string.',
+			});
 		});
 	});
 

--- a/test/cryptography/encrypt.js
+++ b/test/cryptography/encrypt.js
@@ -269,7 +269,7 @@ describe('encrypt', () => {
 				)}gg`;
 				return decryptPassphraseWithPassword
 					.bind(null, cipherIvSaltTagAndVersion, defaultPassword)
-					.should.throw('Tag must be a hex string.');
+					.should.throw('Argument must be a valid hex string.');
 			});
 
 			it('should inform the user if the tag has been altered', () => {

--- a/test/transactions/3_castVotes.js
+++ b/test/transactions/3_castVotes.js
@@ -244,7 +244,7 @@ describe('#castVotes transaction', () => {
 					unvotes: unvotePublicKeys,
 					votes: [plusPrependedPublicKey],
 				})
-				.should.throw('Invalid hex string');
+				.should.throw('Public key must be a valid hex string.');
 		});
 	});
 

--- a/test/transactions/3_castVotes.js
+++ b/test/transactions/3_castVotes.js
@@ -244,7 +244,7 @@ describe('#castVotes transaction', () => {
 					unvotes: unvotePublicKeys,
 					votes: [plusPrependedPublicKey],
 				})
-				.should.throw('Public key must be a valid hex string.');
+				.should.throw('Argument must be a valid hex string.');
 		});
 	});
 

--- a/test/transactions/4_registerMultisignatureAccount.js
+++ b/test/transactions/4_registerMultisignatureAccount.js
@@ -235,7 +235,7 @@ describe('#registerMultisignatureAccount transaction', () => {
 					lifetime,
 					minimum,
 				})
-				.should.throw('Invalid hex string');
+				.should.throw('Public key must be a valid hex string.');
 		});
 	});
 

--- a/test/transactions/4_registerMultisignatureAccount.js
+++ b/test/transactions/4_registerMultisignatureAccount.js
@@ -235,7 +235,7 @@ describe('#registerMultisignatureAccount transaction', () => {
 					lifetime,
 					minimum,
 				})
-				.should.throw('Public key must be a valid hex string.');
+				.should.throw('Argument must be a valid hex string.');
 		});
 	});
 

--- a/test/transactions/utils/validation.js
+++ b/test/transactions/utils/validation.js
@@ -29,7 +29,7 @@ describe('public key validation', () => {
 			it('should throw an error', () => {
 				return validatePublicKey
 					.bind(null, invalidHexPublicKey)
-					.should.throw('Public key must be a valid hex string.');
+					.should.throw('Argument must have a valid length of hex string.');
 			});
 		});
 
@@ -39,7 +39,7 @@ describe('public key validation', () => {
 			it('should throw an error', () => {
 				return validatePublicKey
 					.bind(null, invalidHexPublicKey)
-					.should.throw('Public key must be a valid hex string.');
+					.should.throw('Argument must be a valid hex string.');
 			});
 		});
 
@@ -95,7 +95,7 @@ describe('public key validation', () => {
 			it('should throw an error', () => {
 				return validatePublicKeys
 					.bind(null, publicKeys)
-					.should.throw('Public key must be a valid hex string.');
+					.should.throw('Argument must have a valid length of hex string.');
 			});
 		});
 

--- a/test/transactions/utils/validation.js
+++ b/test/transactions/utils/validation.js
@@ -29,7 +29,7 @@ describe('public key validation', () => {
 			it('should throw an error', () => {
 				return validatePublicKey
 					.bind(null, invalidHexPublicKey)
-					.should.throw('Invalid hex string');
+					.should.throw('Public key must be a valid hex string.');
 			});
 		});
 
@@ -95,7 +95,7 @@ describe('public key validation', () => {
 			it('should throw an error', () => {
 				return validatePublicKeys
 					.bind(null, publicKeys)
-					.should.throw('Invalid hex string');
+					.should.throw('Public key must be a valid hex string.');
 			});
 		});
 


### PR DESCRIPTION
Closes #561 

### Description
- Changed `hexToBuffer` behavior to mimic node version >= 8 in all versions.
- Changed `Buffer.from` to use `hexToBuffer`

### Note
Run test against
* v6.12.3
* v7.10.1
* v8.9.4
* v9.5.0

### Changes
- [x] Update all direct usage of `Buffer.from(hex, 'hex')`
- [x] `Buffer.from(hex, 'hex')` should throw Type error if first argument is not string
- [x] `Buffer.from(hex, 'hex')` should ignore invalid hex string