### PR TITLE
Check amount in getTransactionBytes - Closes #543

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -37,6 +37,8 @@ export const POST = 'POST';
 
 // Largest possible address. Derived from bignum.fromBuffer(Buffer.from(new Array(8).fill(255))).
 export const MAX_ADDRESS_NUMBER = '18446744073709551615';
+// Largest possible amount. Derived from bignum.fromBuffer(Buffer.from(new Array(8).fill(255))).
+export const MAX_TRANSACTION_AMOUNT = '18446744073709551615';
 
 export const TESTNET_NETHASH =
 	'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba';

--- a/test/constants/constants.js
+++ b/test/constants/constants.js
@@ -27,6 +27,7 @@ import {
 	EPOCH_TIME_SECONDS,
 	EPOCH_TIME_MILLISECONDS,
 	MAX_ADDRESS_NUMBER,
+	MAX_TRANSACTION_AMOUNT,
 } from 'constants';
 
 describe('constants', () => {
@@ -84,5 +85,9 @@ describe('constants', () => {
 
 	it('MAX_ADDRESS_NUMBER should be a string', () => {
 		return MAX_ADDRESS_NUMBER.should.be.a('string');
+	});
+
+	it('MAX_TRANSACTION_AMOUNT should be a string', () => {
+		return MAX_TRANSACTION_AMOUNT.should.be.a('string');
 	});
 });

--- a/test/transactions/utils/getTransactionBytes.js
+++ b/test/transactions/utils/getTransactionBytes.js
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import bignum from 'browserify-bignum';
 import getTransactionBytes, {
 	getAssetDataForTransferTransaction,
 	getAssetDataForRegisterSecondSignatureTransaction,
@@ -92,6 +93,40 @@ describe('#getTransactionBytes', () => {
 			return getTransactionBytes
 				.bind(null, defaultTransaction)
 				.should.throw('Transaction asset data exceeds size of 64.');
+		});
+
+		it('should throw on type 0 with an amount that is too small', () => {
+			const amount = -1;
+			defaultTransaction.amount = amount;
+			return getTransactionBytes
+				.bind(null, defaultTransaction)
+				.should.throw('Transaction amount must not be negative.');
+		});
+
+		it('should not throw on type 0 with an amount that is 0', () => {
+			const amount = 0;
+			defaultTransaction.amount = amount;
+			return getTransactionBytes
+				.bind(null, defaultTransaction)
+				.should.not.throw();
+		});
+
+		it('should throw on type 0 with an amount that is too large', () => {
+			const amount = bignum
+				.fromBuffer(Buffer.from(new Array(8).fill(255)))
+				.plus(1);
+			defaultTransaction.amount = amount;
+			return getTransactionBytes
+				.bind(null, defaultTransaction)
+				.should.throw('Transaction amount is too large.');
+		});
+
+		it('should not throw on type 0 with an amount that is the maximum possible', () => {
+			const amount = bignum.fromBuffer(Buffer.from(new Array(8).fill(255)));
+			defaultTransaction.amount = amount;
+			return getTransactionBytes
+				.bind(null, defaultTransaction)
+				.should.not.throw();
 		});
 
 		it('should return Buffer of transaction with second signature', () => {


### PR DESCRIPTION
### What was the problem?

We allowed all amounts as inputs to GTB.

### How did I fix it?

Added checks for amount range. We might want to extend this to other properties too?

### Review checklist

* The PR solves #543 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
