### PR TITLE
Remove to delete never existing dir logs in lisk-elements Jenkins - Closes #590

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,8 +67,5 @@ pipeline {
 		aborted {
 			githubNotify context: 'continuous-integration/jenkins/lisk-js', description: 'The build was aborted.', status: 'ERROR'
 		}
-		always {
-			archiveArtifacts allowEmptyArchive: true, artifacts: 'logs/*'
-		}
 	}
 }


### PR DESCRIPTION
### What was the problem?

Trying to clean up `/logs/*` without it being created ever.

### How did I fix it?

Remove always cleanup step

### How to test it?

`npm t`

### Review checklist

* The PR solves #590
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
