### PR TITLE
Update constants to lisk-constants - Closes #589

### DIFF
--- a/src/api/api_method.js
+++ b/src/api/api_method.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { GET } from 'constants';
+import { GET } from './constants';
 import { solveURLParams, toQueryString } from './utils';
 
 // Bind to resource class

--- a/src/api/constants.js
+++ b/src/api/constants.js
@@ -12,17 +12,10 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { DELEGATE_FEE } from 'lisk-constants';
-import { wrapTransactionCreator } from './utils';
 
-const registerDelegate = ({ username }) => ({
-	type: 2,
-	fee: DELEGATE_FEE.toString(),
-	asset: {
-		delegate: {
-			username,
-		},
-	},
-});
+export const LIVE_PORT = '8000';
+export const TEST_PORT = '7000';
+export const SSL_PORT = '443';
 
-export default wrapTransactionCreator(registerDelegate);
+export const GET = 'GET';
+export const POST = 'POST';

--- a/src/api/lisk_api.js
+++ b/src/api/lisk_api.js
@@ -12,13 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import {
-	LIVE_PORT,
-	SSL_PORT,
-	TEST_PORT,
-	TESTNET_NETHASH,
-	MAINNET_NETHASH,
-} from 'constants';
+import { TESTNET_NETHASH, MAINNET_NETHASH } from 'lisk-constants';
+import { LIVE_PORT, SSL_PORT, TEST_PORT } from './constants';
 import config from '../../config.json';
 import {
 	AccountsResource,

--- a/src/api/lisk_api.js
+++ b/src/api/lisk_api.js
@@ -13,7 +13,6 @@
  *
  */
 import { TESTNET_NETHASH, MAINNET_NETHASH } from 'lisk-constants';
-import { LIVE_PORT, SSL_PORT, TEST_PORT } from './constants';
 import config from '../../config.json';
 import {
 	AccountsResource,
@@ -27,6 +26,7 @@ import {
 	VotersResource,
 	VotesResource,
 } from './resources';
+import { LIVE_PORT, SSL_PORT, TEST_PORT } from './constants';
 
 const commonHeaders = {
 	'Content-Type': 'application/json',

--- a/src/api/resources/accounts.js
+++ b/src/api/resources/accounts.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { GET } from 'constants';
+import { GET } from '../constants';
 import APIResource from '../api_resource';
 import apiMethod from '../api_method';
 

--- a/src/api/resources/blocks.js
+++ b/src/api/resources/blocks.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { GET } from 'constants';
+import { GET } from '../constants';
 import apiMethod from '../api_method';
 import APIResource from '../api_resource';
 

--- a/src/api/resources/dapps.js
+++ b/src/api/resources/dapps.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { GET } from 'constants';
+import { GET } from '../constants';
 import apiMethod from '../api_method';
 import APIResource from '../api_resource';
 

--- a/src/api/resources/delegates.js
+++ b/src/api/resources/delegates.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { GET } from 'constants';
+import { GET } from '../constants';
 import apiMethod from '../api_method';
 import APIResource from '../api_resource';
 

--- a/src/api/resources/node.js
+++ b/src/api/resources/node.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { GET, PUT } from 'constants';
+import { GET, PUT } from '../constants';
 import apiMethod from '../api_method';
 import APIResource from '../api_resource';
 

--- a/src/api/resources/peers.js
+++ b/src/api/resources/peers.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { GET } from 'constants';
+import { GET } from '../constants';
 import apiMethod from '../api_method';
 import APIResource from '../api_resource';
 

--- a/src/api/resources/signatures.js
+++ b/src/api/resources/signatures.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { POST } from 'constants';
+import { POST } from '../constants';
 import apiMethod from '../api_method';
 import APIResource from '../api_resource';
 

--- a/src/api/resources/transactions.js
+++ b/src/api/resources/transactions.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { GET, POST } from 'constants';
+import { GET, POST } from '../constants';
 import apiMethod from '../api_method';
 import APIResource from '../api_resource';
 

--- a/src/api/resources/voters.js
+++ b/src/api/resources/voters.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { GET } from 'constants';
+import { GET } from '../constants';
 import apiMethod from '../api_method';
 import APIResource from '../api_resource';
 

--- a/src/api/resources/votes.js
+++ b/src/api/resources/votes.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { GET } from 'constants';
+import { GET } from '../constants';
 import apiMethod from '../api_method';
 import APIResource from '../api_resource';
 

--- a/src/constants/package.json
+++ b/src/constants/package.json
@@ -1,3 +1,0 @@
-{
-	"name": "constants"
-}

--- a/src/lisk-constants/index.js
+++ b/src/lisk-constants/index.js
@@ -28,14 +28,6 @@ export const EPOCH_TIME = new Date(Date.UTC(2016, 4, 24, 17, 0, 0, 0));
 export const EPOCH_TIME_MILLISECONDS = EPOCH_TIME.getTime();
 export const EPOCH_TIME_SECONDS = Math.floor(EPOCH_TIME.getTime() / 1000);
 
-export const LIVE_PORT = '8000';
-export const TEST_PORT = '7000';
-export const SSL_PORT = '443';
-
-export const GET = 'GET';
-export const POST = 'POST';
-export const PUT = 'PUT';
-
 // Largest possible address. Derived from bignum.fromBuffer(Buffer.from(new Array(8).fill(255))).
 export const MAX_ADDRESS_NUMBER = '18446744073709551615';
 // Largest possible amount. Derived from bignum.fromBuffer(Buffer.from(new Array(8).fill(255))).

--- a/src/lisk-constants/index.js
+++ b/src/lisk-constants/index.js
@@ -12,18 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export const FIXED_POINT = 10 ** 8;
-
-export const TRANSFER_FEE = 0.1 * FIXED_POINT;
-export const DATA_FEE = 0.1 * FIXED_POINT;
-export const IN_TRANSFER_FEE = 0.1 * FIXED_POINT;
-export const OUT_TRANSFER_FEE = 0.1 * FIXED_POINT;
-export const SIGNATURE_FEE = 5 * FIXED_POINT;
-export const DELEGATE_FEE = 25 * FIXED_POINT;
-export const VOTE_FEE = 1 * FIXED_POINT;
-export const MULTISIGNATURE_FEE = 5 * FIXED_POINT;
-export const DAPP_FEE = 25 * FIXED_POINT;
-
 export const EPOCH_TIME = new Date(Date.UTC(2016, 4, 24, 17, 0, 0, 0));
 export const EPOCH_TIME_MILLISECONDS = EPOCH_TIME.getTime();
 export const EPOCH_TIME_SECONDS = Math.floor(EPOCH_TIME.getTime() / 1000);

--- a/src/lisk-constants/package.json
+++ b/src/lisk-constants/package.json
@@ -1,0 +1,3 @@
+{
+	"name": "lisk-constants"
+}

--- a/src/transactions/0_transfer.js
+++ b/src/transactions/0_transfer.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { TRANSFER_FEE, DATA_FEE } from 'constants';
+import { TRANSFER_FEE, DATA_FEE } from 'lisk-constants';
 import {
 	getAddressAndPublicKeyFromRecipientData,
 	wrapTransactionCreator,

--- a/src/transactions/0_transfer.js
+++ b/src/transactions/0_transfer.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { TRANSFER_FEE, DATA_FEE } from 'lisk-constants';
+import { TRANSFER_FEE, DATA_FEE } from './constants';
 import {
 	getAddressAndPublicKeyFromRecipientData,
 	wrapTransactionCreator,

--- a/src/transactions/1_register_second_passphrase.js
+++ b/src/transactions/1_register_second_passphrase.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { SIGNATURE_FEE } from 'constants';
+import { SIGNATURE_FEE } from 'lisk-constants';
 import cryptography from 'cryptography';
 import { wrapTransactionCreator } from './utils';
 

--- a/src/transactions/1_register_second_passphrase.js
+++ b/src/transactions/1_register_second_passphrase.js
@@ -12,8 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { SIGNATURE_FEE } from 'lisk-constants';
 import cryptography from 'cryptography';
+import { SIGNATURE_FEE } from './constants';
 import { wrapTransactionCreator } from './utils';
 
 const registerSecondPassphrase = ({ secondPassphrase }) => {

--- a/src/transactions/2_register_delegate.js
+++ b/src/transactions/2_register_delegate.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { DELEGATE_FEE } from 'lisk-constants';
+import { DELEGATE_FEE } from './constants';
 import { wrapTransactionCreator } from './utils';
 
 const registerDelegate = ({ username }) => ({

--- a/src/transactions/3_cast_votes.js
+++ b/src/transactions/3_cast_votes.js
@@ -12,8 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { VOTE_FEE } from 'lisk-constants';
 import cryptography from 'cryptography';
+import { VOTE_FEE } from './constants';
 import {
 	prependMinusToPublicKeys,
 	prependPlusToPublicKeys,

--- a/src/transactions/3_cast_votes.js
+++ b/src/transactions/3_cast_votes.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { VOTE_FEE } from 'constants';
+import { VOTE_FEE } from 'lisk-constants';
 import cryptography from 'cryptography';
 import {
 	prependMinusToPublicKeys,

--- a/src/transactions/4_register_multisignature_account.js
+++ b/src/transactions/4_register_multisignature_account.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { MULTISIGNATURE_FEE } from 'constants';
+import { MULTISIGNATURE_FEE } from 'lisk-constants';
 import {
 	prependPlusToPublicKeys,
 	validateKeysgroup,

--- a/src/transactions/4_register_multisignature_account.js
+++ b/src/transactions/4_register_multisignature_account.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { MULTISIGNATURE_FEE } from 'lisk-constants';
+import { MULTISIGNATURE_FEE } from './constants';
 import {
 	prependPlusToPublicKeys,
 	validateKeysgroup,

--- a/src/transactions/5_create_dapp.js
+++ b/src/transactions/5_create_dapp.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { DAPP_FEE } from 'lisk-constants';
+import { DAPP_FEE } from './constants';
 import { wrapTransactionCreator } from './utils';
 
 const isInt = n => parseInt(n, 10) === n;

--- a/src/transactions/5_create_dapp.js
+++ b/src/transactions/5_create_dapp.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { DAPP_FEE } from 'constants';
+import { DAPP_FEE } from 'lisk-constants';
 import { wrapTransactionCreator } from './utils';
 
 const isInt = n => parseInt(n, 10) === n;

--- a/src/transactions/6_transfer_into_dapp.js
+++ b/src/transactions/6_transfer_into_dapp.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { IN_TRANSFER_FEE } from 'lisk-constants';
+import { IN_TRANSFER_FEE } from './constants';
 import { wrapTransactionCreator } from './utils';
 
 const transferIntoDapp = ({ amount, dappId }) => ({

--- a/src/transactions/6_transfer_into_dapp.js
+++ b/src/transactions/6_transfer_into_dapp.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { IN_TRANSFER_FEE } from 'constants';
+import { IN_TRANSFER_FEE } from 'lisk-constants';
 import { wrapTransactionCreator } from './utils';
 
 const transferIntoDapp = ({ amount, dappId }) => ({

--- a/src/transactions/7_transfer_out_of_dapp.js
+++ b/src/transactions/7_transfer_out_of_dapp.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { OUT_TRANSFER_FEE } from 'lisk-constants';
+import { OUT_TRANSFER_FEE } from './constants';
 import { wrapTransactionCreator } from './utils';
 
 const transferOutOfDapp = ({ amount, dappId, transactionId, recipientId }) => ({

--- a/src/transactions/7_transfer_out_of_dapp.js
+++ b/src/transactions/7_transfer_out_of_dapp.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { OUT_TRANSFER_FEE } from 'constants';
+import { OUT_TRANSFER_FEE } from 'lisk-constants';
 import { wrapTransactionCreator } from './utils';
 
 const transferOutOfDapp = ({ amount, dappId, transactionId, recipientId }) => ({

--- a/src/transactions/constants.js
+++ b/src/transactions/constants.js
@@ -13,10 +13,14 @@
  *
  */
 
-export const LIVE_PORT = '8000';
-export const TEST_PORT = '7000';
-export const SSL_PORT = '443';
+export const FIXED_POINT = 10 ** 8;
 
-export const GET = 'GET';
-export const POST = 'POST';
-export const PUT = 'PUT';
+export const TRANSFER_FEE = 0.1 * FIXED_POINT;
+export const DATA_FEE = 0.1 * FIXED_POINT;
+export const IN_TRANSFER_FEE = 0.1 * FIXED_POINT;
+export const OUT_TRANSFER_FEE = 0.1 * FIXED_POINT;
+export const SIGNATURE_FEE = 5 * FIXED_POINT;
+export const DELEGATE_FEE = 25 * FIXED_POINT;
+export const VOTE_FEE = 1 * FIXED_POINT;
+export const MULTISIGNATURE_FEE = 5 * FIXED_POINT;
+export const DAPP_FEE = 25 * FIXED_POINT;

--- a/src/transactions/utils/get_transaction_bytes.js
+++ b/src/transactions/utils/get_transaction_bytes.js
@@ -12,8 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { MAX_TRANSACTION_AMOUNT } from 'constants';
 import bignum from 'browserify-bignum';
+import { MAX_TRANSACTION_AMOUNT } from 'lisk-constants';
 import cryptography from 'cryptography';
 
 export const isValidValue = value => ![undefined, false, NaN].includes(value);

--- a/src/transactions/utils/time.js
+++ b/src/transactions/utils/time.js
@@ -13,7 +13,7 @@
  *
  */
 
-import { EPOCH_TIME_MILLISECONDS } from 'constants';
+import { EPOCH_TIME_MILLISECONDS } from 'lisk-constants';
 
 export const getTimeFromBlockchainEpoch = givenTimestamp => {
 	const startingPoint = givenTimestamp || new Date().getTime();

--- a/src/transactions/utils/validation.js
+++ b/src/transactions/utils/validation.js
@@ -12,8 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { MAX_ADDRESS_NUMBER } from 'constants';
 import bignum from 'browserify-bignum';
+import { MAX_ADDRESS_NUMBER } from 'lisk-constants';
 import { hexToBuffer } from 'cryptography/convert';
 
 export const validatePublicKey = publicKey => {

--- a/test/api/constants.js
+++ b/test/api/constants.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import {
+	LIVE_PORT,
+	SSL_PORT,
+	TEST_PORT,
+	GET,
+	POST,
+	PUT,
+	MAINNET_NETHASH,
+	TESTNET_NETHASH,
+} from 'api/constants';
+
+describe('api constants module', () => {
+	it('LIVE_PORT should be a string', () => {
+		return LIVE_PORT.should.be.a('string');
+	});
+
+	it('SSL_PORT should be a string', () => {
+		return SSL_PORT.should.be.a('string');
+	});
+
+	it('TEST_PORT should be a string', () => {
+		return TEST_PORT.should.be.a('string');
+	});
+
+	it('GET should be a string', () => {
+		return GET.should.be.a('string');
+	});
+
+	it('POST should be a string', () => {
+		return POST.should.be.a('string');
+	});
+
+	it('PUT should be a string', () => {
+		return PUT.should.be.a('string');
+	});
+
+	it('MAINNET_NETHASH should be a string', () => {
+		return MAINNET_NETHASH.should.be.a('string');
+	});
+
+	it('TESTNET_NETHASH should be a string', () => {
+		return TESTNET_NETHASH.should.be.a('string');
+	});
+});

--- a/test/api/constants.js
+++ b/test/api/constants.js
@@ -12,16 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import {
-	LIVE_PORT,
-	SSL_PORT,
-	TEST_PORT,
-	GET,
-	POST,
-	PUT,
-	MAINNET_NETHASH,
-	TESTNET_NETHASH,
-} from 'api/constants';
+import { LIVE_PORT, SSL_PORT, TEST_PORT, GET, POST, PUT } from 'api/constants';
 
 describe('api constants module', () => {
 	it('LIVE_PORT should be a string', () => {
@@ -46,13 +37,5 @@ describe('api constants module', () => {
 
 	it('PUT should be a string', () => {
 		return PUT.should.be.a('string');
-	});
-
-	it('MAINNET_NETHASH should be a string', () => {
-		return MAINNET_NETHASH.should.be.a('string');
-	});
-
-	it('TESTNET_NETHASH should be a string', () => {
-		return TESTNET_NETHASH.should.be.a('string');
 	});
 });

--- a/test/lisk-constants/index.js
+++ b/test/lisk-constants/index.js
@@ -13,16 +13,6 @@
  *
  */
 import {
-	FIXED_POINT,
-	DAPP_FEE,
-	DELEGATE_FEE,
-	IN_TRANSFER_FEE,
-	OUT_TRANSFER_FEE,
-	MULTISIGNATURE_FEE,
-	SIGNATURE_FEE,
-	TRANSFER_FEE,
-	VOTE_FEE,
-	DATA_FEE,
 	EPOCH_TIME,
 	EPOCH_TIME_SECONDS,
 	EPOCH_TIME_MILLISECONDS,
@@ -31,46 +21,6 @@ import {
 } from 'lisk-constants';
 
 describe('lisk-constants', () => {
-	it('FIXED_POINT should be an integer', () => {
-		return FIXED_POINT.should.be.an.integer;
-	});
-
-	it('DAPP_FEE should be an integer', () => {
-		return DAPP_FEE.should.be.an.integer;
-	});
-
-	it('DELEGATE_FEE should be an integer', () => {
-		return DELEGATE_FEE.should.be.an.integer;
-	});
-
-	it('IN_TRANSFER_FEE should be an integer', () => {
-		return IN_TRANSFER_FEE.should.be.an.integer;
-	});
-
-	it('OUT_TRANSFER_FEE should be an integer', () => {
-		return OUT_TRANSFER_FEE.should.be.an.integer;
-	});
-
-	it('MULTISIGNATURE_FEE should be an integer', () => {
-		return MULTISIGNATURE_FEE.should.be.an.integer;
-	});
-
-	it('SIGNATURE_FEE should be an integer', () => {
-		return SIGNATURE_FEE.should.be.an.integer;
-	});
-
-	it('TRANSFER_FEE should be an integer', () => {
-		return TRANSFER_FEE.should.be.an.integer;
-	});
-
-	it('VOTE_FEE should be an integer', () => {
-		return VOTE_FEE.should.be.an.integer;
-	});
-
-	it('DATA_FEE should be an integer', () => {
-		return DATA_FEE.should.be.an.integer;
-	});
-
 	it('EPOCH_TIME should be a Date instance', () => {
 		return EPOCH_TIME.should.be.instanceOf(Date);
 	});

--- a/test/lisk-constants/index.js
+++ b/test/lisk-constants/index.js
@@ -28,17 +28,9 @@ import {
 	EPOCH_TIME_MILLISECONDS,
 	MAX_ADDRESS_NUMBER,
 	MAX_TRANSACTION_AMOUNT,
-	LIVE_PORT,
-	SSL_PORT,
-	TEST_PORT,
-	GET,
-	POST,
-	PUT,
-	MAINNET_NETHASH,
-	TESTNET_NETHASH,
-} from 'constants';
+} from 'lisk-constants';
 
-describe('constants', () => {
+describe('lisk-constants', () => {
 	it('FIXED_POINT should be an integer', () => {
 		return FIXED_POINT.should.be.an.integer;
 	});
@@ -97,37 +89,5 @@ describe('constants', () => {
 
 	it('MAX_TRANSACTION_AMOUNT should be a string', () => {
 		return MAX_TRANSACTION_AMOUNT.should.be.a('string');
-	});
-
-	it('LIVE_PORT should be a string', () => {
-		return LIVE_PORT.should.be.a('string');
-	});
-
-	it('SSL_PORT should be a string', () => {
-		return SSL_PORT.should.be.a('string');
-	});
-
-	it('TEST_PORT should be a string', () => {
-		return TEST_PORT.should.be.a('string');
-	});
-
-	it('GET should be a string', () => {
-		return GET.should.be.a('string');
-	});
-
-	it('POST should be a string', () => {
-		return POST.should.be.a('string');
-	});
-
-	it('PUT should be a string', () => {
-		return PUT.should.be.a('string');
-	});
-
-	it('MAINNET_NETHASH should be a string', () => {
-		return MAINNET_NETHASH.should.be.a('string');
-	});
-
-	it('TESTNET_NETHASH should be a string', () => {
-		return TESTNET_NETHASH.should.be.a('string');
 	});
 });

--- a/test/transactions/constants.js
+++ b/test/transactions/constants.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2017 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import {
+	FIXED_POINT,
+	DAPP_FEE,
+	DELEGATE_FEE,
+	IN_TRANSFER_FEE,
+	OUT_TRANSFER_FEE,
+	MULTISIGNATURE_FEE,
+	SIGNATURE_FEE,
+	TRANSFER_FEE,
+	VOTE_FEE,
+	DATA_FEE,
+} from 'transactions/constants';
+
+describe('transactions constants module', () => {
+	it('FIXED_POINT should be an integer', () => {
+		return FIXED_POINT.should.be.an.integer;
+	});
+
+	it('DAPP_FEE should be an integer', () => {
+		return DAPP_FEE.should.be.an.integer;
+	});
+
+	it('DELEGATE_FEE should be an integer', () => {
+		return DELEGATE_FEE.should.be.an.integer;
+	});
+
+	it('IN_TRANSFER_FEE should be an integer', () => {
+		return IN_TRANSFER_FEE.should.be.an.integer;
+	});
+
+	it('OUT_TRANSFER_FEE should be an integer', () => {
+		return OUT_TRANSFER_FEE.should.be.an.integer;
+	});
+
+	it('MULTISIGNATURE_FEE should be an integer', () => {
+		return MULTISIGNATURE_FEE.should.be.an.integer;
+	});
+
+	it('SIGNATURE_FEE should be an integer', () => {
+		return SIGNATURE_FEE.should.be.an.integer;
+	});
+
+	it('TRANSFER_FEE should be an integer', () => {
+		return TRANSFER_FEE.should.be.an.integer;
+	});
+
+	it('VOTE_FEE should be an integer', () => {
+		return VOTE_FEE.should.be.an.integer;
+	});
+
+	it('DATA_FEE should be an integer', () => {
+		return DATA_FEE.should.be.an.integer;
+	});
+});


### PR DESCRIPTION
### What was the problem?
- Package specific constants were exposed to global
- Package `constants` had conflict with node build-in package name

### How did I fix it?
- change package name to `lisk-constants`
- move package specific constants to `constants.js`

### Review checklist 

* The PR solves #589
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
