### PR TITLE
Update test to use expect instead of should - Closes #576

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -4,7 +4,7 @@
 	},
 	"globals": {
 		"sandbox": true,
-		"should": true,
+		"expect": true,
 		"sinon": true
 	},
 	"rules": {

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -69,12 +69,14 @@ describe('APIClient module', () => {
 		});
 
 		it('should create a new instance of APIClient', () => {
-			return apiClient.should.be.an('object').and.be.instanceof(APIClient);
+			return expect(apiClient)
+				.to.be.an('object')
+				.and.be.instanceof(APIClient);
 		});
 
 		it('should call initialize', () => {
 			apiClient = new APIClient(defaultNodes, mainnetHash);
-			return initializeStub.should.be.calledOnce;
+			return expect(initializeStub).to.be.calledOnce;
 		});
 	});
 
@@ -86,15 +88,15 @@ describe('APIClient module', () => {
 		});
 
 		it('should return APIClient instance', () => {
-			return client.should.be.instanceof(APIClient);
+			return expect(client).to.be.instanceof(APIClient);
 		});
 
 		it('should contain mainnet nodes', () => {
-			return client.nodes.should.eql(mainnetNodes);
+			return expect(client.nodes).to.eql(mainnetNodes);
 		});
 
 		it('should be set to mainnet hash', () => {
-			return client.headers.nethash.should.equal(mainnetHash);
+			return expect(client.headers.nethash).to.equal(mainnetHash);
 		});
 	});
 
@@ -106,59 +108,62 @@ describe('APIClient module', () => {
 		});
 
 		it('should return APIClient instance', () => {
-			return client.should.be.instanceof(APIClient);
+			return expect(client).to.be.instanceof(APIClient);
 		});
 
 		it('should contain testnet nodes', () => {
-			return client.nodes.should.eql(testnetNodes);
+			return expect(client.nodes).to.eql(testnetNodes);
 		});
 
 		it('should be set to testnet hash', () => {
-			return client.headers.nethash.should.equal(testnetHash);
+			return expect(client.headers.nethash).to.equal(testnetHash);
 		});
 	});
 
 	describe('#initialize', () => {
 		it('should throw an error if no arguments are passed to constructor', () => {
-			return apiClient.initialize
-				.bind(apiClient)
-				.should.throw(Error, 'APIClient requires nodes for initialization.');
+			return expect(apiClient.initialize.bind(apiClient)).to.throw(
+				Error,
+				'APIClient requires nodes for initialization.',
+			);
 		});
 
 		it('should throw an error if first argument passed to constructor is not array', () => {
-			return apiClient.initialize
-				.bind(apiClient, 'non-array')
-				.should.throw(Error, 'APIClient requires nodes for initialization.');
+			return expect(apiClient.initialize.bind(apiClient, 'non-array')).to.throw(
+				Error,
+				'APIClient requires nodes for initialization.',
+			);
 		});
 
 		it('should throw an error if first argument passed to constructor is empty array', () => {
-			return apiClient.initialize
-				.bind(apiClient, [])
-				.should.throw(Error, 'APIClient requires nodes for initialization.');
+			return expect(apiClient.initialize.bind(apiClient, [])).to.throw(
+				Error,
+				'APIClient requires nodes for initialization.',
+			);
 		});
 
 		it('should throw an error if no second argument is passed to constructor', () => {
-			return apiClient.initialize
-				.bind(apiClient, defaultNodes)
-				.should.throw(Error, 'APIClient requires nethash for initialization.');
+			return expect(
+				apiClient.initialize.bind(apiClient, defaultNodes),
+			).to.throw(Error, 'APIClient requires nethash for initialization.');
 		});
 
 		it('should throw an error if second argument passed to constructor is not string', () => {
-			return apiClient.initialize
-				.bind(apiClient, defaultNodes, 123)
-				.should.throw(Error, 'APIClient requires nethash for initialization.');
+			return expect(
+				apiClient.initialize.bind(apiClient, defaultNodes, 123),
+			).to.throw(Error, 'APIClient requires nethash for initialization.');
 		});
 
 		it('should throw an error if second argument passed to constructor is empty string', () => {
-			return apiClient.initialize
-				.bind(apiClient, defaultNodes, '')
-				.should.throw(Error, 'APIClient requires nethash for initialization.');
+			return expect(
+				apiClient.initialize.bind(apiClient, defaultNodes, ''),
+			).to.throw(Error, 'APIClient requires nethash for initialization.');
 		});
 
 		describe('headers', () => {
 			it('should set with passed nethash, with default options', () => {
-				return apiClient.should.have
-					.property('headers')
+				return expect(apiClient)
+					.to.have.property('headers')
 					.and.eql(defaultHeaders);
 			});
 
@@ -167,41 +172,48 @@ describe('APIClient module', () => {
 					version: customHeaders.version,
 					minVersion: customHeaders.minVersion,
 				});
-				return apiClient.should.have.property('headers').and.eql(customHeaders);
+				return expect(apiClient)
+					.to.have.property('headers')
+					.and.eql(customHeaders);
 			});
 		});
 
 		describe('nodes', () => {
 			it('should have nodes supplied to constructor', () => {
-				return apiClient.should.have.property('nodes').and.equal(defaultNodes);
+				return expect(apiClient)
+					.to.have.property('nodes')
+					.and.equal(defaultNodes);
 			});
 		});
 
 		describe('bannedNodes', () => {
 			it('should set empty array if no option is passed', () => {
-				return apiClient.should.have.property('bannedNodes').be.eql([]);
+				return expect(apiClient)
+					.to.have.property('bannedNodes')
+					.be.eql([]);
 			});
 
 			it('should set bannedNodes when passed as an option', () => {
 				const bannedNodes = ['a', 'b'];
 				apiClient = new APIClient(defaultNodes, mainnetHash, { bannedNodes });
-				return apiClient.should.have
-					.property('bannedNodes')
+				return expect(apiClient)
+					.to.have.property('bannedNodes')
 					.be.eql(bannedNodes);
 			});
 		});
 
 		describe('currentNode', () => {
 			it('should set with random node with initialized setup if no node is specified by options', () => {
-				return apiClient.should.have.property('currentNode').and.not.be.empty;
+				return expect(apiClient).to.have.property('currentNode').and.not.be
+					.empty;
 			});
 
 			it('should set with supplied node if node is specified by options', () => {
 				apiClient = new APIClient(defaultNodes, mainnetHash, {
 					node: externalTestnetNode,
 				});
-				return apiClient.should.have
-					.property('currentNode')
+				return expect(apiClient)
+					.to.have.property('currentNode')
 					.and.equal(externalTestnetNode);
 			});
 		});
@@ -211,21 +223,21 @@ describe('APIClient module', () => {
 				apiClient = new APIClient(defaultNodes, mainnetHash, {
 					randomizeNodes: undefined,
 				});
-				return apiClient.should.have.property('randomizeNodes').be.true;
+				return expect(apiClient).to.have.property('randomizeNodes').be.true;
 			});
 
 			it('should set randomizeNodes to true on initialization when passed as an option', () => {
 				apiClient = new APIClient(defaultNodes, mainnetHash, {
 					randomizeNodes: true,
 				});
-				return apiClient.should.have.property('randomizeNodes').be.true;
+				return expect(apiClient).to.have.property('randomizeNodes').be.true;
 			});
 
 			it('should set randomizeNodes to false on initialization when passed as an option', () => {
 				apiClient = new APIClient(defaultNodes, mainnetHash, {
 					randomizeNodes: false,
 				});
-				return apiClient.should.have.property('randomizeNodes').be.false;
+				return expect(apiClient).to.have.property('randomizeNodes').be.false;
 			});
 		});
 	});
@@ -233,14 +245,14 @@ describe('APIClient module', () => {
 	describe('#getNewNode', () => {
 		it('should throw an error if all relevant nodes are banned', () => {
 			apiClient.bannedNodes = [...defaultNodes];
-			return apiClient.getNewNode
-				.bind(apiClient)
-				.should.throw('Cannot get new node: all nodes have been banned.');
+			return expect(apiClient.getNewNode.bind(apiClient)).to.throw(
+				'Cannot get new node: all nodes have been banned.',
+			);
 		});
 
 		it('should return a node', () => {
 			const result = apiClient.getNewNode();
-			return defaultNodes.should.contain(result);
+			return expect(defaultNodes).to.contain(result);
 		});
 
 		it('should randomly select the node', () => {
@@ -257,8 +269,8 @@ describe('APIClient module', () => {
 	describe('#banNode', () => {
 		it('should add node to banned nodes', () => {
 			const banned = apiClient.banNode(localNode);
-			banned.should.be.true;
-			return apiClient.isBanned(localNode).should.be.true;
+			expect(banned).to.be.true;
+			return expect(apiClient.isBanned(localNode)).to.be.true;
 		});
 
 		it('should not duplicate a banned node', () => {
@@ -266,8 +278,8 @@ describe('APIClient module', () => {
 			apiClient.bannedNodes = bannedNodes;
 			const banned = apiClient.banNode(localNode);
 
-			banned.should.be.false;
-			return apiClient.bannedNodes.should.be.eql(bannedNodes);
+			expect(banned).to.be.false;
+			return expect(apiClient.bannedNodes).to.be.eql(bannedNodes);
 		});
 	});
 
@@ -281,8 +293,8 @@ describe('APIClient module', () => {
 
 		it('should add current node to banned nodes', () => {
 			const banned = apiClient.banActiveNode();
-			banned.should.be.true;
-			return apiClient.isBanned(currentNode).should.be.true;
+			expect(banned).to.be.true;
+			return expect(apiClient.isBanned(currentNode)).to.be.true;
 		});
 
 		it('should not duplicate a banned node', () => {
@@ -290,8 +302,8 @@ describe('APIClient module', () => {
 			apiClient.bannedNodes = bannedNodes;
 			const banned = apiClient.banActiveNode();
 
-			banned.should.be.false;
-			return apiClient.bannedNodes.should.be.eql(bannedNodes);
+			expect(banned).to.be.false;
+			return expect(apiClient.bannedNodes).to.be.eql(bannedNodes);
 		});
 	});
 
@@ -309,30 +321,30 @@ describe('APIClient module', () => {
 
 		it('should call ban current node', () => {
 			apiClient.banActiveNodeAndSelect();
-			return apiClient.isBanned(currentNode).should.be.true;
+			return expect(apiClient.isBanned(currentNode)).to.be.true;
 		});
 
 		it('should call selectNewNode when the node is banned', () => {
 			apiClient.banActiveNodeAndSelect();
-			return getNewNodeStub.should.be.calledOnce;
+			return expect(getNewNodeStub).to.be.calledOnce;
 		});
 
 		it('should not call selectNewNode when the node is not banned', () => {
 			const bannedNodes = [currentNode];
 			apiClient.bannedNodes = bannedNodes;
 			apiClient.banActiveNodeAndSelect();
-			return getNewNodeStub.should.not.be.called;
+			return expect(getNewNodeStub).not.to.be.called;
 		});
 	});
 
 	describe('#isBanned', () => {
 		it('should return true when provided node is banned', () => {
 			apiClient.bannedNodes.push(localNode);
-			return apiClient.isBanned(localNode).should.be.true;
+			return expect(apiClient.isBanned(localNode)).to.be.true;
 		});
 
 		it('should return false when provided node is not banned', () => {
-			return apiClient.isBanned(localNode).should.be.false;
+			return expect(apiClient.isBanned(localNode)).to.be.false;
 		});
 	});
 
@@ -340,12 +352,12 @@ describe('APIClient module', () => {
 		it('should return false without nodes left', () => {
 			apiClient.bannedNodes = [...defaultNodes];
 			const result = apiClient.hasAvailableNodes();
-			return result.should.be.false;
+			return expect(result).to.be.false;
 		});
 
 		it('should return true if nodes are available', () => {
 			const result = apiClient.hasAvailableNodes();
-			return result.should.be.true;
+			return expect(result).to.be.true;
 		});
 	});
 });

--- a/test/api_client/api_method.js
+++ b/test/api_client/api_method.js
@@ -59,13 +59,13 @@ describe('API method module', () => {
 			});
 
 			it('should return function', () => {
-				return handler.should.be.a('function');
+				return expect(handler).to.be.a('function');
 			});
 
 			it('should request GET with default URL', () => {
 				return handler().then(() => {
-					resource.request.should.be.calledOnce;
-					return resource.request.should.be.calledWithExactly(
+					expect(resource.request).to.be.calledOnce;
+					return expect(resource.request).to.be.calledWithExactly(
 						{
 							method: GET,
 							url: defaultFullPath,
@@ -97,31 +97,31 @@ describe('API method module', () => {
 			});
 
 			it('should return function', () => {
-				return handler.should.be.a('function');
+				return expect(handler).to.be.a('function');
 			});
 
 			it('should be rejected with error without param', () => {
-				return handler().should.be.rejectedWith(Error, errorArgumentNumber);
+				return expect(handler()).to.be.rejectedWith(Error, errorArgumentNumber);
 			});
 
 			it('should be rejected with error without enough param', () => {
-				return handler(firstURLParam).should.be.rejectedWith(
+				return expect(handler(firstURLParam)).to.be.rejectedWith(
 					Error,
 					errorArgumentNumber,
 				);
 			});
 
 			it('should be rejected with no data', () => {
-				return handler(firstURLParam, secondURLParam).should.be.rejectedWith(
-					validationError,
-				);
+				return expect(
+					handler(firstURLParam, secondURLParam),
+				).to.be.rejectedWith(validationError);
 			});
 
 			it('should call request with the given data', () => {
 				return handler(firstURLParam, secondURLParam, { needed: true }).then(
 					() => {
-						resource.request.should.be.calledOnce;
-						return resource.request.should.be.calledWithExactly(
+						expect(resource.request).to.be.calledOnce;
+						return expect(resource.request).to.be.calledWithExactly(
 							{
 								method: POST,
 								url: `${defaultFullPath}/${firstURLParam}/ids/${
@@ -159,31 +159,31 @@ describe('API method module', () => {
 			});
 
 			it('should return a function', () => {
-				return handler.should.be.a('function');
+				return expect(handler).to.be.a('function');
 			});
 
 			it('should be rejected with error without parameters', () => {
-				return handler().should.be.rejectedWith(Error, errorArgumentNumber);
+				return expect(handler()).to.be.rejectedWith(Error, errorArgumentNumber);
 			});
 
 			it('should be rejected with error without enough parameters', () => {
-				return handler(firstURLParam).should.be.rejectedWith(
+				return expect(handler(firstURLParam)).to.be.rejectedWith(
 					Error,
 					errorArgumentNumber,
 				);
 			});
 
 			it('should be rejected with no data', () => {
-				return handler(firstURLParam, secondURLParam).should.be.rejectedWith(
-					validationError,
-				);
+				return expect(
+					handler(firstURLParam, secondURLParam),
+				).to.be.rejectedWith(validationError);
 			});
 
 			it('should be request with the given data', () => {
 				return handler(firstURLParam, secondURLParam, { needed: true }).then(
 					() => {
-						resource.request.should.be.calledOnce;
-						return resource.request.should.be.calledWithExactly(
+						expect(resource.request).to.be.calledOnce;
+						return expect(resource.request).to.be.calledWithExactly(
 							{
 								method: GET,
 								url: `${defaultFullPath}/${firstURLParam}/ids/${

--- a/test/api_client/api_resource.js
+++ b/test/api_client/api_resource.js
@@ -57,11 +57,11 @@ describe('API resource module', () => {
 
 	describe('#constructor', () => {
 		it('should create an API resource instance', () => {
-			return resource.should.be.instanceOf(APIResource);
+			return expect(resource).to.be.instanceOf(APIResource);
 		});
 
 		it('should throw an error without an input', () => {
-			return (() => new APIResource()).should.throw(
+			return expect(() => new APIResource()).to.throw(
 				'APIResource requires APIClient instance for initialization.',
 			);
 		});
@@ -69,18 +69,18 @@ describe('API resource module', () => {
 
 	describe('get headers', () => {
 		it('should return header set to apiClient', () => {
-			return resource.headers.should.eql(defaultHeaders);
+			return expect(resource.headers).to.eql(defaultHeaders);
 		});
 	});
 
 	describe('get resourcePath', () => {
 		it('should return the resource’s full path', () => {
-			return resource.resourcePath.should.equal(`${defaultBasePath}/api`);
+			return expect(resource.resourcePath).to.equal(`${defaultBasePath}/api`);
 		});
 
 		it('should return the resource’s full path with set path', () => {
 			resource.path = defaultResourcePath;
-			return resource.resourcePath.should.equal(
+			return expect(resource.resourcePath).to.equal(
 				`${defaultBasePath}/api${defaultResourcePath}`,
 			);
 		});
@@ -100,17 +100,17 @@ describe('API resource module', () => {
 
 		it('should make a request to API without calling retry', () => {
 			return resource.request(defaultRequest, false).then(res => {
-				popsicleStub.should.be.calledOnce;
-				handleRetryStub.should.not.be.called;
-				return res.should.eql(sendRequestResult.body);
+				expect(popsicleStub).to.be.calledOnce;
+				expect(handleRetryStub).not.to.be.called;
+				return expect(res).to.eql(sendRequestResult.body);
 			});
 		});
 
 		it('should make a request to API without calling retry when it successes', () => {
 			return resource.request(defaultRequest, true).then(res => {
-				popsicleStub.should.be.calledOnce;
-				handleRetryStub.should.not.be.called;
-				return res.should.eql(sendRequestResult.body);
+				expect(popsicleStub).to.be.calledOnce;
+				expect(handleRetryStub).not.to.be.called;
+				return expect(res).to.eql(sendRequestResult.body);
 			});
 		});
 
@@ -119,9 +119,9 @@ describe('API resource module', () => {
 				use: () => Promise.reject(defaultError),
 			});
 			return resource.request(defaultRequest, true).catch(err => {
-				popsicleStub.should.be.calledOnce;
-				handleRetryStub.should.be.calledOnce;
-				return err.should.eql(defaultError);
+				expect(popsicleStub).to.be.calledOnce;
+				expect(handleRetryStub).to.be.calledOnce;
+				return expect(err).to.eql(defaultError);
 			});
 		});
 	});
@@ -153,9 +153,9 @@ describe('API resource module', () => {
 				const req = resource.handleRetry(defaultError, defaultRequest);
 				clock.tick(1000);
 				return req.then(res => {
-					apiClient.banActiveNodeAndSelect.should.be.calledOnce;
-					requestStub.should.be.calledWith(defaultRequest, true);
-					return res.should.be.eql(sendRequestResult.body);
+					expect(apiClient.banActiveNodeAndSelect).to.be.calledOnce;
+					expect(requestStub).to.be.calledWith(defaultRequest, true);
+					return expect(res).to.be.eql(sendRequestResult.body);
 				});
 			});
 
@@ -164,9 +164,9 @@ describe('API resource module', () => {
 				const req = resource.handleRetry(defaultError, defaultRequest);
 				clock.tick(1000);
 				return req.then(res => {
-					apiClient.banActiveNodeAndSelect.should.not.be.called;
-					requestStub.should.be.calledWith(defaultRequest, true);
-					return res.should.be.eql(sendRequestResult.body);
+					expect(apiClient.banActiveNodeAndSelect).not.to.be.called;
+					expect(requestStub).to.be.calledWith(defaultRequest, true);
+					return expect(res).to.be.eql(sendRequestResult.body);
 				});
 			});
 		});
@@ -180,9 +180,9 @@ describe('API resource module', () => {
 			it('should resolve with failure response', () => {
 				const req = resource.handleRetry(defaultError, defaultRequest);
 				return req.then(res => {
-					res.success.should.be.false;
-					res.error.should.eql(defaultError);
-					return res.message.should.equal(
+					expect(res.success).to.be.false;
+					expect(res.error).to.eql(defaultError);
+					return expect(res.message).to.equal(
 						'Could not create an HTTP request to any known nodes.',
 					);
 				});

--- a/test/api_client/constants.js
+++ b/test/api_client/constants.js
@@ -16,14 +16,14 @@ import { GET, POST, PUT } from 'api_client/constants';
 
 describe('api constants module', () => {
 	it('GET should be a string', () => {
-		return GET.should.be.a('string');
+		return expect(GET).to.be.a('string');
 	});
 
 	it('POST should be a string', () => {
-		return POST.should.be.a('string');
+		return expect(POST).to.be.a('string');
 	});
 
 	it('PUT should be a string', () => {
-		return PUT.should.be.a('string');
+		return expect(PUT).to.be.a('string');
 	});
 });

--- a/test/api_client/resources/accounts.js
+++ b/test/api_client/resources/accounts.js
@@ -37,36 +37,40 @@ describe('AccountsResource', () => {
 
 	describe('#constructor', () => {
 		it('should throw error without apiClient input', () => {
-			return (() => new AccountsResource()).should.throw(
+			return expect(() => new AccountsResource()).to.throw(
 				'APIResource requires APIClient instance for initialization.',
 			);
 		});
 
 		it('should be instance of APIResource', () => {
-			return resource.should.be.instanceOf(APIResource);
+			return expect(resource).to.be.instanceOf(APIResource);
 		});
 
 		it('should have correct full path', () => {
-			return resource.resourcePath.should.eql(`${defaultBasePath}/api${path}`);
+			return expect(resource.resourcePath).to.eql(
+				`${defaultBasePath}/api${path}`,
+			);
 		});
 
 		it('should set resource path', () => {
-			return resource.path.should.equal(path);
+			return expect(resource.path).to.equal(path);
 		});
 
 		it('should have a "get" function', () => {
-			return resource.should.have.property('get').which.is.a('function');
+			return expect(resource)
+				.to.have.property('get')
+				.which.is.a('function');
 		});
 
 		it('should have a "getMultisignatureGroup" function', () => {
-			return resource.should.have
-				.property('getMultisignatureGroup')
+			return expect(resource)
+				.to.have.property('getMultisignatureGroup')
 				.which.is.a('function');
 		});
 
 		it('should have a "getMultisignatureMembership" function', () => {
-			return resource.should.have
-				.property('getMultisignatureMembership')
+			return expect(resource)
+				.to.have.property('getMultisignatureMembership')
 				.which.is.a('function');
 		});
 	});

--- a/test/api_client/resources/blocks.js
+++ b/test/api_client/resources/blocks.js
@@ -37,25 +37,29 @@ describe('BlocksResource', () => {
 
 	describe('#constructor', () => {
 		it('should throw error without apiClient input', () => {
-			return (() => new BlocksResource()).should.throw(
+			return expect(() => new BlocksResource()).to.throw(
 				'APIResource requires APIClient instance for initialization.',
 			);
 		});
 
 		it('should be instance of APIResource', () => {
-			return resource.should.be.instanceOf(APIResource);
+			return expect(resource).to.be.instanceOf(APIResource);
 		});
 
 		it('should have correct full path', () => {
-			return resource.resourcePath.should.eql(`${defaultBasePath}/api${path}`);
+			return expect(resource.resourcePath).to.eql(
+				`${defaultBasePath}/api${path}`,
+			);
 		});
 
 		it('should set resource path', () => {
-			return resource.path.should.equal(path);
+			return expect(resource.path).to.equal(path);
 		});
 
 		it('should have a "get" function', () => {
-			return resource.should.have.property('get').which.is.a('function');
+			return expect(resource)
+				.to.have.property('get')
+				.which.is.a('function');
 		});
 	});
 });

--- a/test/api_client/resources/dapps.js
+++ b/test/api_client/resources/dapps.js
@@ -37,25 +37,29 @@ describe('DappsResource', () => {
 
 	describe('#constructor', () => {
 		it('should throw error without apiClient input', () => {
-			return (() => new DappsResource()).should.throw(
+			return expect(() => new DappsResource()).to.throw(
 				'APIResource requires APIClient instance for initialization.',
 			);
 		});
 
 		it('should be instance of APIResource', () => {
-			return resource.should.be.instanceOf(APIResource);
+			return expect(resource).to.be.instanceOf(APIResource);
 		});
 
 		it('should have correct full path', () => {
-			return resource.resourcePath.should.eql(`${defaultBasePath}/api${path}`);
+			return expect(resource.resourcePath).to.eql(
+				`${defaultBasePath}/api${path}`,
+			);
 		});
 
 		it('should set resource path', () => {
-			return resource.path.should.equal(path);
+			return expect(resource.path).to.equal(path);
 		});
 
 		it('should have a "get" function', () => {
-			return resource.should.have.property('get').which.is.a('function');
+			return expect(resource)
+				.to.have.property('get')
+				.which.is.a('function');
 		});
 	});
 });

--- a/test/api_client/resources/delegates.js
+++ b/test/api_client/resources/delegates.js
@@ -37,38 +37,46 @@ describe('DelegatesResource', () => {
 
 	describe('#constructor', () => {
 		it('should throw error without apiClient input', () => {
-			return (() => new DelegatesResource()).should.throw(
+			return expect(() => new DelegatesResource()).to.throw(
 				'APIResource requires APIClient instance for initialization.',
 			);
 		});
 
 		it('should be instance of APIResource', () => {
-			return resource.should.be.instanceOf(APIResource);
+			return expect(resource).to.be.instanceOf(APIResource);
 		});
 
 		it('should have correct full path', () => {
-			return resource.resourcePath.should.eql(`${defaultBasePath}/api${path}`);
+			return expect(resource.resourcePath).to.eql(
+				`${defaultBasePath}/api${path}`,
+			);
 		});
 
 		it('should set resource path', () => {
-			return resource.path.should.equal(path);
+			return expect(resource.path).to.equal(path);
 		});
 
 		it('should have a "get" function', () => {
-			return resource.should.have.property('get').which.is.a('function');
+			return expect(resource)
+				.to.have.property('get')
+				.which.is.a('function');
 		});
 
 		it('should have a "getStandby" function', () => {
-			return resource.should.have.property('getStandby').which.is.a('function');
+			return expect(resource)
+				.to.have.property('getStandby')
+				.which.is.a('function');
 		});
 
 		it('should have a "getForgers" function', () => {
-			return resource.should.have.property('getForgers').which.is.a('function');
+			return expect(resource)
+				.to.have.property('getForgers')
+				.which.is.a('function');
 		});
 
 		it('should have a "getForgingStats" function', () => {
-			return resource.should.have
-				.property('getForgingStats')
+			return expect(resource)
+				.to.have.property('getForgingStats')
 				.which.is.a('function');
 		});
 	});

--- a/test/api_client/resources/node.js
+++ b/test/api_client/resources/node.js
@@ -37,48 +37,52 @@ describe('NodeResource', () => {
 
 	describe('#constructor', () => {
 		it('should throw error without apiClient input', () => {
-			return (() => new NodeResource()).should.throw(
+			return expect(() => new NodeResource()).to.throw(
 				'APIResource requires APIClient instance for initialization.',
 			);
 		});
 
 		it('should be instance of APIResource', () => {
-			return resource.should.be.instanceOf(APIResource);
+			return expect(resource).to.be.instanceOf(APIResource);
 		});
 
 		it('should have correct full path', () => {
-			return resource.resourcePath.should.eql(`${defaultBasePath}/api${path}`);
+			return expect(resource.resourcePath).to.eql(
+				`${defaultBasePath}/api${path}`,
+			);
 		});
 
 		it('should set resource path', () => {
-			return resource.path.should.equal(path);
+			return expect(resource.path).to.equal(path);
 		});
 
 		it('should have a "getConstants" function', () => {
-			return resource.should.have
-				.property('getConstants')
+			return expect(resource)
+				.to.have.property('getConstants')
 				.which.is.a('function');
 		});
 
 		it('should have a "getStatus" function', () => {
-			return resource.should.have.property('getStatus').which.is.a('function');
+			return expect(resource)
+				.to.have.property('getStatus')
+				.which.is.a('function');
 		});
 
 		it('should have a "getForgingStatus" function', () => {
-			return resource.should.have
-				.property('getForgingStatus')
+			return expect(resource)
+				.to.have.property('getForgingStatus')
 				.which.is.a('function');
 		});
 
 		it('should have a "updateForgingStatus" function', () => {
-			return resource.should.have
-				.property('updateForgingStatus')
+			return expect(resource)
+				.to.have.property('updateForgingStatus')
 				.which.is.a('function');
 		});
 
 		it('should have a "getTransactions" function', () => {
-			return resource.should.have
-				.property('getTransactions')
+			return expect(resource)
+				.to.have.property('getTransactions')
 				.which.is.a('function');
 		});
 	});

--- a/test/api_client/resources/peers.js
+++ b/test/api_client/resources/peers.js
@@ -37,25 +37,29 @@ describe('PeersResource', () => {
 
 	describe('#constructor', () => {
 		it('should throw error without apiClient input', () => {
-			return (() => new PeersResource()).should.throw(
+			return expect(() => new PeersResource()).to.throw(
 				'APIResource requires APIClient instance for initialization.',
 			);
 		});
 
 		it('should be instance of APIResource', () => {
-			return resource.should.be.instanceOf(APIResource);
+			return expect(resource).to.be.instanceOf(APIResource);
 		});
 
 		it('should have correct full path', () => {
-			return resource.resourcePath.should.eql(`${defaultBasePath}/api${path}`);
+			return expect(resource.resourcePath).to.eql(
+				`${defaultBasePath}/api${path}`,
+			);
 		});
 
 		it('should set resource path', () => {
-			return resource.path.should.equal(path);
+			return expect(resource.path).to.equal(path);
 		});
 
 		it('should have a "get" function', () => {
-			return resource.should.have.property('get').which.is.a('function');
+			return expect(resource)
+				.to.have.property('get')
+				.which.is.a('function');
 		});
 	});
 });

--- a/test/api_client/resources/signatures.js
+++ b/test/api_client/resources/signatures.js
@@ -37,25 +37,29 @@ describe('SignaturesResource', () => {
 
 	describe('#constructor', () => {
 		it('should throw error without apiClient input', () => {
-			return (() => new SignaturesResource()).should.throw(
+			return expect(() => new SignaturesResource()).to.throw(
 				'APIResource requires APIClient instance for initialization.',
 			);
 		});
 
 		it('should be instance of APIResource', () => {
-			return resource.should.be.instanceOf(APIResource);
+			return expect(resource).to.be.instanceOf(APIResource);
 		});
 
 		it('should have correct full path', () => {
-			return resource.resourcePath.should.eql(`${defaultBasePath}/api${path}`);
+			return expect(resource.resourcePath).to.eql(
+				`${defaultBasePath}/api${path}`,
+			);
 		});
 
 		it('should set resource path', () => {
-			return resource.path.should.equal(path);
+			return expect(resource.path).to.equal(path);
 		});
 
 		it('should have a "broadcast" function', () => {
-			return resource.should.have.property('broadcast').which.is.a('function');
+			return expect(resource)
+				.to.have.property('broadcast')
+				.which.is.a('function');
 		});
 	});
 });

--- a/test/api_client/resources/transactions.js
+++ b/test/api_client/resources/transactions.js
@@ -37,29 +37,35 @@ describe('TransactionsResource', () => {
 
 	describe('#constructor', () => {
 		it('should throw error without apiClient input', () => {
-			return (() => new TransactionsResource()).should.throw(
+			return expect(() => new TransactionsResource()).to.throw(
 				'APIResource requires APIClient instance for initialization.',
 			);
 		});
 
 		it('should be instance of APIResource', () => {
-			return resource.should.be.instanceOf(APIResource);
+			return expect(resource).to.be.instanceOf(APIResource);
 		});
 
 		it('should have correct full path', () => {
-			return resource.resourcePath.should.eql(`${defaultBasePath}/api${path}`);
+			return expect(resource.resourcePath).to.eql(
+				`${defaultBasePath}/api${path}`,
+			);
 		});
 
 		it('should set resource path', () => {
-			return resource.path.should.equal(path);
+			return expect(resource.path).to.equal(path);
 		});
 
 		it('should have a "get" function', () => {
-			return resource.should.have.property('get').which.is.a('function');
+			return expect(resource)
+				.to.have.property('get')
+				.which.is.a('function');
 		});
 
 		it('should have a "broadcast" function', () => {
-			return resource.should.have.property('broadcast').which.is.a('function');
+			return expect(resource)
+				.to.have.property('broadcast')
+				.which.is.a('function');
 		});
 	});
 });

--- a/test/api_client/resources/voters.js
+++ b/test/api_client/resources/voters.js
@@ -37,25 +37,29 @@ describe('VotersResource', () => {
 
 	describe('#constructor', () => {
 		it('should throw error without apiClient input', () => {
-			return (() => new VotersResource()).should.throw(
+			return expect(() => new VotersResource()).to.throw(
 				'APIResource requires APIClient instance for initialization.',
 			);
 		});
 
 		it('should be instance of APIResource', () => {
-			return resource.should.be.instanceOf(APIResource);
+			return expect(resource).to.be.instanceOf(APIResource);
 		});
 
 		it('should have correct full path', () => {
-			return resource.resourcePath.should.eql(`${defaultBasePath}/api${path}`);
+			return expect(resource.resourcePath).to.eql(
+				`${defaultBasePath}/api${path}`,
+			);
 		});
 
 		it('should set resource path', () => {
-			return resource.path.should.equal(path);
+			return expect(resource.path).to.equal(path);
 		});
 
 		it('should have a "get" function', () => {
-			return resource.should.have.property('get').which.is.a('function');
+			return expect(resource)
+				.to.have.property('get')
+				.which.is.a('function');
 		});
 	});
 });

--- a/test/api_client/resources/votes.js
+++ b/test/api_client/resources/votes.js
@@ -37,25 +37,29 @@ describe('VotesResource', () => {
 
 	describe('#constructor', () => {
 		it('should throw error without apiClient input', () => {
-			return (() => new VotesResource()).should.throw(
+			return expect(() => new VotesResource()).to.throw(
 				'APIResource requires APIClient instance for initialization.',
 			);
 		});
 
 		it('should be instance of APIResource', () => {
-			return resource.should.be.instanceOf(APIResource);
+			return expect(resource).to.be.instanceOf(APIResource);
 		});
 
 		it('should have correct full path', () => {
-			return resource.resourcePath.should.eql(`${defaultBasePath}/api${path}`);
+			return expect(resource.resourcePath).to.eql(
+				`${defaultBasePath}/api${path}`,
+			);
 		});
 
 		it('should set resource path', () => {
-			return resource.path.should.equal(path);
+			return expect(resource.path).to.equal(path);
 		});
 
 		it('should have a "get" function', () => {
-			return resource.should.have.property('get').which.is.a('function');
+			return expect(resource)
+				.to.have.property('get')
+				.which.is.a('function');
 		});
 	});
 });

--- a/test/api_client/utils.js
+++ b/test/api_client/utils.js
@@ -24,33 +24,38 @@ describe('api utils module', () => {
 				key2: 'value2',
 				key3: 'value3',
 			});
-			return queryString.should.be.equal('key1=value1&key2=value2&key3=value3');
+			return expect(queryString).to.be.equal(
+				'key1=value1&key2=value2&key3=value3',
+			);
 		});
 
 		it('should escape invalid special characters', () => {
 			const queryString = toQueryString({
 				'key:/;?': 'value:/;?',
 			});
-			return queryString.should.be.equal('key%3A%2F%3B%3F=value%3A%2F%3B%3F');
+			return expect(queryString).to.be.equal(
+				'key%3A%2F%3B%3F=value%3A%2F%3B%3F',
+			);
 		});
 	});
 
 	describe('#solveURLParams', () => {
 		it('should return original URL with no param', () => {
 			const solvedURL = solveURLParams(defaultURL);
-			return solvedURL.should.be.equal(defaultURL);
+			return expect(solvedURL).to.be.equal(defaultURL);
 		});
 
 		it('should throw error if url has variable but no param', () => {
-			return solveURLParams
-				.bind(null, `${defaultURL}/{id}`)
-				.should.throw(Error, 'URL is not completely solved');
+			return expect(solveURLParams.bind(null, `${defaultURL}/{id}`)).to.throw(
+				Error,
+				'URL is not completely solved',
+			);
 		});
 
 		it('should throw error if url has variable but not matching params', () => {
-			return solveURLParams
-				.bind(null, `${defaultURL}/{id}`, { accountId: '123' })
-				.should.throw(Error, 'URL is not completely solved');
+			return expect(
+				solveURLParams.bind(null, `${defaultURL}/{id}`, { accountId: '123' }),
+			).to.throw(Error, 'URL is not completely solved');
 		});
 
 		it('should replace variable with correct id', () => {
@@ -58,7 +63,7 @@ describe('api utils module', () => {
 				id: '456',
 				accountId: '123',
 			});
-			return solvedURL.should.be.equal(`${defaultURL}/456`);
+			return expect(solvedURL).to.be.equal(`${defaultURL}/456`);
 		});
 
 		it('should replace multiple variables with correct id and accountId', () => {
@@ -66,7 +71,7 @@ describe('api utils module', () => {
 				id: '456',
 				accountId: '123',
 			});
-			return solvedURL.should.be.equal(`${defaultURL}/123/456`);
+			return expect(solvedURL).to.be.equal(`${defaultURL}/123/456`);
 		});
 
 		it('should replace variable with correct id and encode special characters', () => {
@@ -74,7 +79,7 @@ describe('api utils module', () => {
 				id: '456ß1234sd',
 				accountId: '123',
 			});
-			return solvedURL.should.be.equal(`${defaultURL}/456%C3%9F1234sd`);
+			return expect(solvedURL).to.be.equal(`${defaultURL}/456%C3%9F1234sd`);
 		});
 	});
 });

--- a/test/cryptography/convert.js
+++ b/test/cryptography/convert.js
@@ -56,59 +56,63 @@ describe('convert', () => {
 	describe('#bufferToHex', () => {
 		it('should create a hex string from a Buffer', () => {
 			const hex = bufferToHex(defaultBuffer);
-			return hex.should.be.equal(defaultHex);
+			return expect(hex).to.be.equal(defaultHex);
 		});
 	});
 
 	describe('#hexToBuffer', () => {
 		it('should create a Buffer from a hex string', () => {
 			const buffer = hexToBuffer(defaultHex);
-			return buffer.should.be.eql(defaultBuffer);
+			return expect(buffer).to.be.eql(defaultBuffer);
 		});
 
 		it('should throw TypeError with number', () => {
-			return hexToBuffer
-				.bind(null, 123)
-				.should.throw(TypeError, 'Argument must be a string.');
+			return expect(hexToBuffer.bind(null, 123)).to.throw(
+				TypeError,
+				'Argument must be a string.',
+			);
 		});
 
 		it('should throw TypeError with object', () => {
-			return hexToBuffer
-				.bind(null, {})
-				.should.throw(TypeError, 'Argument must be a string.');
+			return expect(hexToBuffer.bind(null, {})).to.throw(
+				TypeError,
+				'Argument must be a string.',
+			);
 		});
 
 		it('should throw TypeError with non hex string', () => {
-			return hexToBuffer
-				.bind(null, 'yKJj')
-				.should.throw(TypeError, 'Argument must be a valid hex string.');
+			return expect(hexToBuffer.bind(null, 'yKJj')).to.throw(
+				TypeError,
+				'Argument must be a valid hex string.',
+			);
 		});
 
 		it('should throw TypeError with partially correct hex string', () => {
-			return hexToBuffer
-				.bind(null, 'Abxzzzz')
-				.should.throw(TypeError, 'Argument must be a valid hex string.');
+			return expect(hexToBuffer.bind(null, 'Abxzzzz')).to.throw(
+				TypeError,
+				'Argument must be a valid hex string.',
+			);
 		});
 
 		it('should throw TypeError with odd number of string with partially correct hex string', () => {
-			return hexToBuffer
-				.bind(null, 'Abxzzab')
-				.should.throw(TypeError, 'Argument must be a valid hex string.');
+			return expect(hexToBuffer.bind(null, 'Abxzzab')).to.throw(
+				TypeError,
+				'Argument must be a valid hex string.',
+			);
 		});
 
 		it('should throw TypeError with odd number hex string with invalid hex', () => {
-			return hexToBuffer
-				.bind(null, '123xxxx')
-				.should.throw(TypeError, 'Argument must be a valid hex string.');
+			return expect(hexToBuffer.bind(null, '123xxxx')).to.throw(
+				TypeError,
+				'Argument must be a valid hex string.',
+			);
 		});
 
 		it('should throw TypeError with odd number of hex string', () => {
-			return hexToBuffer
-				.bind(null, 'c3a5c3a4c3b6a')
-				.should.throw(
-					TypeError,
-					'Argument must have a valid length of hex string.',
-				);
+			return expect(hexToBuffer.bind(null, 'c3a5c3a4c3b6a')).to.throw(
+				TypeError,
+				'Argument must have a valid length of hex string.',
+			);
 		});
 	});
 
@@ -116,7 +120,7 @@ describe('convert', () => {
 		it('should get the first eight bytes reversed from a Buffer', () => {
 			const bufferEntry = Buffer.from(defaultStringWithMoreThanEightCharacters);
 			const reversedAndCut = getFirstEightBytesReversed(bufferEntry);
-			return reversedAndCut.should.be.eql(
+			return expect(reversedAndCut).to.be.eql(
 				Buffer.from(defaultFirstEightCharactersReversed),
 			);
 		});
@@ -125,7 +129,7 @@ describe('convert', () => {
 			const reversedAndCut = getFirstEightBytesReversed(
 				defaultStringWithMoreThanEightCharacters,
 			);
-			return reversedAndCut.should.be.eql(
+			return expect(reversedAndCut).to.be.eql(
 				Buffer.from(defaultFirstEightCharactersReversed),
 			);
 		});
@@ -135,7 +139,7 @@ describe('convert', () => {
 		it('should create an address from a buffer', () => {
 			const bufferInit = Buffer.from(defaultDataForBuffer);
 			const address = toAddress(bufferInit);
-			return address.should.be.eql(defaultAddressFromBuffer);
+			return expect(address).to.be.eql(defaultAddressFromBuffer);
 		});
 	});
 
@@ -146,7 +150,7 @@ describe('convert', () => {
 
 		it('should generate address from publicKey', () => {
 			const address = getAddressFromPublicKey(defaultPublicKey);
-			return address.should.be.equal(defaultAddress);
+			return expect(address).to.be.equal(defaultAddress);
 		});
 	});
 
@@ -157,23 +161,25 @@ describe('convert', () => {
 
 		it('should generate address from publicKey', () => {
 			const address = getAddress(defaultPublicKey);
-			return address.should.be.equal(defaultAddress);
+			return expect(address).to.be.equal(defaultAddress);
 		});
 	});
 
 	describe('#convertPublicKeyEd2Curve', () => {
 		it('should convert publicKey ED25519 to Curve25519 key', () => {
 			const curveRepresentation = convertPublicKeyEd2Curve(defaultPublicKey);
-			return defaultPublicKeyCurve.equals(Buffer.from(curveRepresentation))
-				.should.be.true;
+			return expect(
+				defaultPublicKeyCurve.equals(Buffer.from(curveRepresentation)),
+			).to.be.true;
 		});
 	});
 
 	describe('#convertPrivateKeyEd2Curve', () => {
 		it('should convert privateKey ED25519 to Curve25519 key', () => {
 			const curveRepresentation = convertPrivateKeyEd2Curve(defaultPrivateKey);
-			return defaultPrivateKeyCurve.equals(Buffer.from(curveRepresentation))
-				.should.be.true;
+			return expect(
+				defaultPrivateKeyCurve.equals(Buffer.from(curveRepresentation)),
+			).to.be.true;
 		});
 	});
 
@@ -182,7 +188,7 @@ describe('convert', () => {
 			const bigNumber = '58191285901858109';
 			const addressSize = 8;
 			const expectedBuffer = Buffer.from('00cebcaa8d34153d', 'hex');
-			return bigNumberToBuffer(bigNumber, addressSize).should.be.eql(
+			return expect(bigNumberToBuffer(bigNumber, addressSize)).to.be.eql(
 				expectedBuffer,
 			);
 		});
@@ -192,7 +198,7 @@ describe('convert', () => {
 		it('should convert a buffer to a big number', () => {
 			const bigNumber = '58191285901858109';
 			const buffer = Buffer.from('00cebcaa8d34153d', 'hex');
-			return bufferToBigNumberString(buffer).should.be.equal(bigNumber);
+			return expect(bufferToBigNumberString(buffer)).to.be.equal(bigNumber);
 		});
 	});
 });

--- a/test/cryptography/encrypt.js
+++ b/test/cryptography/encrypt.js
@@ -108,14 +108,14 @@ describe('encrypt', () => {
 		});
 
 		it('should encrypt a message', () => {
-			return encryptedMessage.should.have
-				.property('encryptedMessage')
+			return expect(encryptedMessage)
+				.to.have.property('encryptedMessage')
 				.be.hexString.with.length(68);
 		});
 
 		it('should output the nonce', () => {
-			return encryptedMessage.should.have
-				.property('nonce')
+			return expect(encryptedMessage)
+				.to.have.property('nonce')
 				.be.hexString.with.length(48);
 		});
 	});
@@ -129,33 +129,33 @@ describe('encrypt', () => {
 				defaultPublicKey,
 			);
 
-			return decryptedMessage.should.be.equal(defaultMessage);
+			return expect(decryptedMessage).to.be.equal(defaultMessage);
 		});
 
 		it('should inform the user if the nonce is the wrong length', () => {
-			return decryptMessageWithPassphrase
-				.bind(
+			return expect(
+				decryptMessageWithPassphrase.bind(
 					null,
 					defaultEncryptedMessageWithNonce.encryptedMessage,
 					defaultEncryptedMessageWithNonce.encryptedMessage.slice(0, 2),
 					defaultPassphrase,
 					defaultPublicKey,
-				)
-				.should.throw('Expected 24-byte nonce but got length 1.');
+				),
+			).to.throw('Expected 24-byte nonce but got length 1.');
 		});
 
 		it('should inform the user if something goes wrong during decryption', () => {
-			return decryptMessageWithPassphrase
-				.bind(
+			return expect(
+				decryptMessageWithPassphrase.bind(
 					null,
 					defaultEncryptedMessageWithNonce.encryptedMessage.slice(0, 2),
 					defaultEncryptedMessageWithNonce.nonce,
 					defaultSecondPassphrase,
 					defaultPublicKey,
-				)
-				.should.throw(
-					'Something went wrong during decryption. Is this the full encrypted message?',
-				);
+				),
+			).to.throw(
+				'Something went wrong during decryption. Is this the full encrypted message?',
+			);
 		});
 	});
 
@@ -183,39 +183,41 @@ describe('encrypt', () => {
 			});
 
 			it('should encrypt a passphrase', () => {
-				return cipher.should.have.property('cipher').and.be.hexString;
+				return expect(cipher).to.have.property('cipher').and.be.hexString;
 			});
 
 			it('should output the IV', () => {
-				return cipher.should.have
-					.property('iv')
+				return expect(cipher)
+					.to.have.property('iv')
 					.and.be.hexString.and.have.length(32);
 			});
 
 			it('should output the salt', () => {
-				return cipher.should.have
-					.property('salt')
+				return expect(cipher)
+					.to.have.property('salt')
 					.and.be.hexString.and.have.length(32);
 			});
 
 			it('should output the tag', () => {
-				return cipher.should.have
-					.property('tag')
+				return expect(cipher)
+					.to.have.property('tag')
 					.and.be.hexString.and.have.length(32);
 			});
 
 			it('should output the current version of LiskJS', () => {
-				return cipher.should.have.property('version').which.is.equal(version);
+				return expect(cipher)
+					.to.have.property('version')
+					.which.is.equal(version);
 			});
 
 			it('should take more than 0.5 seconds @node-only', () => {
 				const endTime = Date.now();
-				return (endTime - startTime).should.be.above(500);
+				return expect(endTime - startTime).to.be.above(500);
 			});
 
 			it('should take less than 2 seconds @node-only', () => {
 				const endTime = Date.now();
-				return (endTime - startTime).should.be.below(2e3);
+				return expect(endTime - startTime).to.be.below(2e3);
 			});
 		});
 
@@ -239,16 +241,20 @@ describe('encrypt', () => {
 					cipherIvSaltTagAndVersion,
 					defaultPassword,
 				);
-				return decrypted.should.be.eql(defaultPassphrase);
+				return expect(decrypted).to.be.eql(defaultPassphrase);
 			});
 
 			it('should inform the user if the salt has been altered', () => {
 				cipherIvSaltTagAndVersion.salt = `00${cipherIvSaltTagAndVersion.salt.slice(
 					2,
 				)}`;
-				return decryptPassphraseWithPassword
-					.bind(null, cipherIvSaltTagAndVersion, defaultPassword)
-					.should.throw('Unsupported state or unable to authenticate data');
+				return expect(
+					decryptPassphraseWithPassword.bind(
+						null,
+						cipherIvSaltTagAndVersion,
+						defaultPassword,
+					),
+				).to.throw('Unsupported state or unable to authenticate data');
 			});
 
 			it('should inform the user if the tag has been shortened', () => {
@@ -256,9 +262,13 @@ describe('encrypt', () => {
 					0,
 					30,
 				);
-				return decryptPassphraseWithPassword
-					.bind(null, cipherIvSaltTagAndVersion, defaultPassword)
-					.should.throw('Tag must be 16 bytes.');
+				return expect(
+					decryptPassphraseWithPassword.bind(
+						null,
+						cipherIvSaltTagAndVersion,
+						defaultPassword,
+					),
+				).to.throw('Tag must be 16 bytes.');
 			});
 
 			it('should inform the user if the tag is not a hex string', () => {
@@ -266,18 +276,26 @@ describe('encrypt', () => {
 					0,
 					30,
 				)}gg`;
-				return decryptPassphraseWithPassword
-					.bind(null, cipherIvSaltTagAndVersion, defaultPassword)
-					.should.throw('Argument must be a valid hex string.');
+				return expect(
+					decryptPassphraseWithPassword.bind(
+						null,
+						cipherIvSaltTagAndVersion,
+						defaultPassword,
+					),
+				).to.throw('Argument must be a valid hex string.');
 			});
 
 			it('should inform the user if the tag has been altered', () => {
 				cipherIvSaltTagAndVersion.tag = `00${cipherIvSaltTagAndVersion.tag.slice(
 					2,
 				)}`;
-				return decryptPassphraseWithPassword
-					.bind(null, cipherIvSaltTagAndVersion, defaultPassword)
-					.should.throw('Unsupported state or unable to authenticate data');
+				return expect(
+					decryptPassphraseWithPassword.bind(
+						null,
+						cipherIvSaltTagAndVersion,
+						defaultPassword,
+					),
+				).to.throw('Unsupported state or unable to authenticate data');
 			});
 		});
 
@@ -291,7 +309,7 @@ describe('encrypt', () => {
 					cipher,
 					defaultPassword,
 				);
-				return decryptedString.should.be.eql(defaultPassphrase);
+				return expect(decryptedString).to.be.eql(defaultPassphrase);
 			});
 		});
 	});

--- a/test/cryptography/hash.js
+++ b/test/cryptography/hash.js
@@ -31,33 +31,29 @@ describe('hash', () => {
 	it('should generate a sha256 hash from a Buffer', () => {
 		const testBuffer = Buffer.from(defaultText);
 		const hash = hashFunction(testBuffer);
-		return hash.should.be.eql(defaultHash);
+		return expect(hash).to.be.eql(defaultHash);
 	});
 
 	it('should generate a sha256 hash from a utf8 string', () => {
 		const hash = hashFunction(defaultText, 'utf8');
-		return hash.should.be.eql(defaultHash);
+		return expect(hash).to.be.eql(defaultHash);
 	});
 
 	it('should generate a sha256 hash from a hex string', () => {
 		const testHex = Buffer.from(defaultText).toString('hex');
 		const hash = hashFunction(testHex, 'hex');
-		return hash.should.be.eql(defaultHash);
+		return expect(hash).to.be.eql(defaultHash);
 	});
 
 	it('should throw on unknown format when trying a string with format "utf32"', () => {
-		return hashFunction
-			.bind(null, defaultText, 'utf32')
-			.should.throw(
-				'Unsupported string format. Currently only `hex` and `utf8` are supported.',
-			);
+		return expect(hashFunction.bind(null, defaultText, 'utf32')).to.throw(
+			'Unsupported string format. Currently only `hex` and `utf8` are supported.',
+		);
 	});
 
 	it('should throw on unknown format when using an array', () => {
-		return hashFunction
-			.bind(null, arrayToHash)
-			.should.throw(
-				'Unsupported data format. Currently only Buffers or `hex` and `utf8` strings are supported.',
-			);
+		return expect(hashFunction.bind(null, arrayToHash)).to.throw(
+			'Unsupported data format. Currently only Buffers or `hex` and `utf8` strings are supported.',
+		);
 	});
 });

--- a/test/cryptography/index.js
+++ b/test/cryptography/index.js
@@ -16,6 +16,6 @@ import cryptography from 'cryptography';
 
 describe('cryptography index.js', () => {
 	it('should export an object', () => {
-		return cryptography.should.be.an('object');
+		return expect(cryptography).to.be.an('object');
 	});
 });

--- a/test/cryptography/keys.js
+++ b/test/cryptography/keys.js
@@ -59,15 +59,15 @@ describe('keys', () => {
 		});
 
 		it('should create buffer publicKey', () => {
-			return Buffer.from(keyPair.publicKey)
-				.toString('hex')
-				.should.be.equal(defaultPublicKey);
+			return expect(Buffer.from(keyPair.publicKey).toString('hex')).to.be.equal(
+				defaultPublicKey,
+			);
 		});
 
 		it('should create buffer privateKey', () => {
-			return Buffer.from(keyPair.privateKey)
-				.toString('hex')
-				.should.be.equal(defaultPrivateKey);
+			return expect(
+				Buffer.from(keyPair.privateKey).toString('hex'),
+			).to.be.equal(defaultPrivateKey);
 		});
 	});
 
@@ -80,14 +80,14 @@ describe('keys', () => {
 		});
 
 		it('should generate the correct publicKey from a passphrase', () => {
-			return keyPair.should.have
-				.property('publicKey')
+			return expect(keyPair)
+				.to.have.property('publicKey')
 				.and.be.equal(defaultPublicKey);
 		});
 
 		it('should generate the correct privateKey from a passphrase', () => {
-			return keyPair.should.have
-				.property('privateKey')
+			return expect(keyPair)
+				.to.have.property('privateKey')
 				.and.be.equal(defaultPrivateKey);
 		});
 	});
@@ -101,23 +101,23 @@ describe('keys', () => {
 		});
 
 		it('should generate the correct publicKey from a passphrase', () => {
-			return keyPair.should.have
-				.property('publicKey')
+			return expect(keyPair)
+				.to.have.property('publicKey')
 				.and.be.equal(defaultPublicKey);
 		});
 
 		it('should generate the correct privateKey from a passphrase', () => {
-			return keyPair.should.have
-				.property('privateKey')
+			return expect(keyPair)
+				.to.have.property('privateKey')
 				.and.be.equal(defaultPrivateKey);
 		});
 	});
 
 	describe('#getAddressAndPublicKeyFromPassphrase', () => {
 		it('should create correct address and publicKey', () => {
-			return getAddressAndPublicKeyFromPassphrase(defaultPassphrase).should.eql(
-				defaultAddressAndPublicKey,
-			);
+			return expect(
+				getAddressAndPublicKeyFromPassphrase(defaultPassphrase),
+			).to.eql(defaultAddressAndPublicKey);
 		});
 	});
 });

--- a/test/cryptography/sign.js
+++ b/test/cryptography/sign.js
@@ -120,29 +120,29 @@ ${defaultSecondSignature}
 				defaultMessage,
 				defaultPassphrase,
 			);
-			return signedMessage.should.be.eql(defaultSignedMessage);
+			return expect(signedMessage).to.be.eql(defaultSignedMessage);
 		});
 	});
 
 	describe('#verifyMessageWithPublicKey', () => {
 		it('should detect invalid publicKeys', () => {
-			return verifyMessageWithPublicKey
-				.bind(null, {
+			return expect(
+				verifyMessageWithPublicKey.bind(null, {
 					message: defaultMessage,
 					signature: defaultSignature,
 					publicKey: changeLength(defaultPublicKey),
-				})
-				.should.throw('Invalid publicKey, expected 32-byte publicKey');
+				}),
+			).to.throw('Invalid publicKey, expected 32-byte publicKey');
 		});
 
 		it('should detect invalid signatures', () => {
-			return verifyMessageWithPublicKey
-				.bind(null, {
+			return expect(
+				verifyMessageWithPublicKey.bind(null, {
 					message: defaultMessage,
 					signature: changeLength(defaultSignature),
 					publicKey: defaultPublicKey,
-				})
-				.should.throw('Invalid signature length, expected 64-byte signature');
+				}),
+			).to.throw('Invalid signature length, expected 64-byte signature');
 		});
 
 		it('should return false if the signature is invalid', () => {
@@ -151,12 +151,12 @@ ${defaultSecondSignature}
 				signature: makeInvalid(defaultSignature),
 				publicKey: defaultPublicKey,
 			});
-			return verification.should.be.false;
+			return expect(verification).to.be.false;
 		});
 
 		it('should return true if the signature is valid', () => {
 			const verification = verifyMessageWithPublicKey(defaultSignedMessage);
-			return verification.should.be.true;
+			return expect(verification).to.be.true;
 		});
 	});
 
@@ -168,57 +168,53 @@ ${defaultSecondSignature}
 				defaultSecondPassphrase,
 			);
 
-			return signature.should.be.eql(defaultDoubleSignedMessage);
+			return expect(signature).to.be.eql(defaultDoubleSignedMessage);
 		});
 	});
 
 	describe('#verifyMessageWithTwoPublicKeys', () => {
 		it('should throw on invalid first publicKey length', () => {
-			return verifyMessageWithTwoPublicKeys
-				.bind(
+			return expect(
+				verifyMessageWithTwoPublicKeys.bind(
 					null,
 					Object.assign({}, defaultDoubleSignedMessage, {
 						publicKey: changeLength(defaultPublicKey),
 					}),
-				)
-				.should.throw('Invalid first publicKey, expected 32-byte publicKey');
+				),
+			).to.throw('Invalid first publicKey, expected 32-byte publicKey');
 		});
 
 		it('should throw on invalid second publicKey length', () => {
-			return verifyMessageWithTwoPublicKeys
-				.bind(
+			return expect(
+				verifyMessageWithTwoPublicKeys.bind(
 					null,
 					Object.assign({}, defaultDoubleSignedMessage, {
 						secondPublicKey: changeLength(defaultSecondPublicKey),
 					}),
-				)
-				.should.throw('Invalid second publicKey, expected 32-byte publicKey');
+				),
+			).to.throw('Invalid second publicKey, expected 32-byte publicKey');
 		});
 
 		it('should throw on invalid primary signature length', () => {
-			return verifyMessageWithTwoPublicKeys
-				.bind(
+			return expect(
+				verifyMessageWithTwoPublicKeys.bind(
 					null,
 					Object.assign({}, defaultDoubleSignedMessage, {
 						signature: changeLength(defaultSignature),
 					}),
-				)
-				.should.throw(
-					'Invalid first signature length, expected 64-byte signature',
-				);
+				),
+			).to.throw('Invalid first signature length, expected 64-byte signature');
 		});
 
 		it('should throw on invalid secondary signature length', () => {
-			return verifyMessageWithTwoPublicKeys
-				.bind(
+			return expect(
+				verifyMessageWithTwoPublicKeys.bind(
 					null,
 					Object.assign({}, defaultDoubleSignedMessage, {
 						secondSignature: changeLength(defaultSecondSignature),
 					}),
-				)
-				.should.throw(
-					'Invalid second signature length, expected 64-byte signature',
-				);
+				),
+			).to.throw('Invalid second signature length, expected 64-byte signature');
 		});
 
 		it('should return false for incorrect first signature', () => {
@@ -227,7 +223,7 @@ ${defaultSecondSignature}
 					signature: makeInvalid(defaultSignature),
 				}),
 			);
-			return verified.should.be.false;
+			return expect(verified).to.be.false;
 		});
 
 		it('should return false for incorrect second signature', () => {
@@ -236,14 +232,14 @@ ${defaultSecondSignature}
 					secondSignature: makeInvalid(defaultSecondSignature),
 				}),
 			);
-			return verified.should.be.false;
+			return expect(verified).to.be.false;
 		});
 
 		it('should return true for two valid signatures', () => {
 			const verified = verifyMessageWithTwoPublicKeys(
 				defaultDoubleSignedMessage,
 			);
-			return verified.should.be.true;
+			return expect(verified).to.be.true;
 		});
 	});
 
@@ -254,7 +250,7 @@ ${defaultSecondSignature}
 				signature: defaultSignature,
 				publicKey: defaultPublicKey,
 			});
-			return printedMessage.should.be.equal(defaultPrintedMessage);
+			return expect(printedMessage).to.be.equal(defaultPrintedMessage);
 		});
 
 		it('should wrap a second signed message into a printed Lisk template', () => {
@@ -265,7 +261,9 @@ ${defaultSecondSignature}
 				secondSignature: defaultSecondSignature,
 				secondPublicKey: defaultSecondPublicKey,
 			});
-			return printedMessage.should.be.equal(defaultSecondSignedPrintedMessage);
+			return expect(printedMessage).to.be.equal(
+				defaultSecondSignedPrintedMessage,
+			);
 		});
 	});
 
@@ -275,7 +273,7 @@ ${defaultSecondSignature}
 				defaultMessage,
 				defaultPassphrase,
 			);
-			return signedAndPrintedMessage.should.be.equal(defaultPrintedMessage);
+			return expect(signedAndPrintedMessage).to.be.equal(defaultPrintedMessage);
 		});
 
 		it('should sign the message twice and wrap it into a printed Lisk template', () => {
@@ -284,7 +282,7 @@ ${defaultSecondSignature}
 				defaultPassphrase,
 				defaultSecondPassphrase,
 			);
-			return signedAndPrintedMessage.should.be.equal(
+			return expect(signedAndPrintedMessage).to.be.equal(
 				defaultSecondSignedPrintedMessage,
 			);
 		});
@@ -299,7 +297,7 @@ ${defaultSecondSignature}
 		});
 
 		it('should sign a transaction', () => {
-			return signature.should.be.equal(defaultDataSignature);
+			return expect(signature).to.be.equal(defaultDataSignature);
 		});
 	});
 
@@ -310,7 +308,7 @@ ${defaultSecondSignature}
 				makeInvalid(defaultDataSignature),
 				defaultPublicKey,
 			);
-			return verification.should.be.false;
+			return expect(verification).to.be.false;
 		});
 
 		it('should return true for a valid signature', () => {
@@ -319,7 +317,7 @@ ${defaultSecondSignature}
 				defaultDataSignature,
 				defaultPublicKey,
 			);
-			return verification.should.be.true;
+			return expect(verification).to.be.true;
 		});
 	});
 });

--- a/test/lisk-constants/index.js
+++ b/test/lisk-constants/index.js
@@ -26,38 +26,38 @@ import {
 
 describe('lisk-constants', () => {
 	it('EPOCH_TIME should be a Date instance', () => {
-		return EPOCH_TIME.should.be.instanceOf(Date);
+		return expect(EPOCH_TIME).to.be.instanceOf(Date);
 	});
 
 	it('EPOCH_TIME_SECONDS should be an integer', () => {
-		return EPOCH_TIME_SECONDS.should.be.an.integer;
+		return expect(EPOCH_TIME_SECONDS).to.be.an.integer;
 	});
 
 	it('EPOCH_TIME_MILLISECONDS should be an integer', () => {
-		return EPOCH_TIME_MILLISECONDS.should.be.an.integer;
+		return expect(EPOCH_TIME_MILLISECONDS).to.be.an.integer;
 	});
 
 	it('MAX_ADDRESS_NUMBER should be a string', () => {
-		return MAX_ADDRESS_NUMBER.should.be.a('string');
+		return expect(MAX_ADDRESS_NUMBER).to.be.a('string');
 	});
 
 	it('MAX_TRANSACTION_AMOUNT should be a string', () => {
-		return MAX_TRANSACTION_AMOUNT.should.be.a('string');
+		return expect(MAX_TRANSACTION_AMOUNT).to.be.a('string');
 	});
 
 	it('TESTNET_NETHASH should be a string', () => {
-		return TESTNET_NETHASH.should.be.a('string');
+		return expect(TESTNET_NETHASH).to.be.a('string');
 	});
 
 	it('TESTNET_NODES should be a string', () => {
-		return TESTNET_NODES.should.be.an('array');
+		return expect(TESTNET_NODES).to.be.an('array');
 	});
 
 	it('MAINNET_NETHASH should be a string', () => {
-		return MAINNET_NETHASH.should.be.a('string');
+		return expect(MAINNET_NETHASH).to.be.a('string');
 	});
 
 	it('MAINNET_NODES should be a string', () => {
-		return MAINNET_NODES.should.be.an('array');
+		return expect(MAINNET_NODES).to.be.an('array');
 	});
 });

--- a/test/passphrase/index.js
+++ b/test/passphrase/index.js
@@ -16,18 +16,18 @@ import passphrase from 'passphrase';
 
 describe('passphrase index.js', () => {
 	it('should export an object', () => {
-		return passphrase.should.be.an('object');
+		return expect(passphrase).to.be.an('object');
 	});
 
 	describe('menmonic module', () => {
 		it('should have the BIP39 Mnemonic module', () => {
-			return passphrase.Mnemonic.should.be.ok;
+			return expect(passphrase.Mnemonic).to.be.ok;
 		});
 	});
 
 	describe('validation module', () => {
 		it('should have the validation module', () => {
-			return passphrase.validation.should.be.ok;
+			return expect(passphrase.validation).to.be.ok;
 		});
 	});
 });

--- a/test/passphrase/validation.js
+++ b/test/passphrase/validation.js
@@ -30,7 +30,7 @@ describe('passphrase validation', () => {
 				'model actor shallow eight glue upper seat lobster reason label enlist bridge';
 
 			it('should return the expected amount of whitespaces', () => {
-				return countPassphraseWhitespaces(passphrase).should.be.equal(
+				return expect(countPassphraseWhitespaces(passphrase)).to.be.equal(
 					expectedAmountOfWhitespaces,
 				);
 			});
@@ -42,7 +42,7 @@ describe('passphrase validation', () => {
 				'model actor shallow eight glue upper seat lobster reason label enlist bridge ';
 
 			it('should return the expected amount of whitespaces', () => {
-				return countPassphraseWhitespaces(passphrase).should.be.equal(
+				return expect(countPassphraseWhitespaces(passphrase)).to.be.equal(
 					expectedAmountOfWhitespaces,
 				);
 			});
@@ -54,7 +54,7 @@ describe('passphrase validation', () => {
 				' model actor shallow eight glue upper seat lobster reason label enlist bridge';
 
 			it('should return the expected amount of whitespaces', () => {
-				return countPassphraseWhitespaces(passphrase).should.be.equal(
+				return expect(countPassphraseWhitespaces(passphrase)).to.be.equal(
 					expectedAmountOfWhitespaces,
 				);
 			});
@@ -66,7 +66,7 @@ describe('passphrase validation', () => {
 				'model  actor shallow eight glue upper seat lobster reason label enlist bridge';
 
 			it('should return the expected amount of whitespaces', () => {
-				return countPassphraseWhitespaces(passphrase).should.be.equal(
+				return expect(countPassphraseWhitespaces(passphrase)).to.be.equal(
 					expectedAmountOfWhitespaces,
 				);
 			});
@@ -78,7 +78,7 @@ describe('passphrase validation', () => {
 				'model  actor  shallow  eight  glue  upper  seat  lobster  reason  label  enlist  bridge';
 
 			it('should return the expected amount of whitespaces', () => {
-				return countPassphraseWhitespaces(passphrase).should.be.equal(
+				return expect(countPassphraseWhitespaces(passphrase)).to.be.equal(
 					expectedAmountOfWhitespaces,
 				);
 			});
@@ -90,7 +90,7 @@ describe('passphrase validation', () => {
 				'\tmodel actor shallow eight glue upper seat lobster reason label enlist bridge';
 
 			it('should return the expected amount of whitespaces', () => {
-				return countPassphraseWhitespaces(passphrase).should.be.equal(
+				return expect(countPassphraseWhitespaces(passphrase)).to.be.equal(
 					expectedAmountOfWhitespaces,
 				);
 			});
@@ -102,7 +102,7 @@ describe('passphrase validation', () => {
 				'\vmodel actor shallow eight glue upper seat lobster reason label enlist bridge';
 
 			it('should return the expected amount of whitespaces', () => {
-				return countPassphraseWhitespaces(passphrase).should.be.equal(
+				return expect(countPassphraseWhitespaces(passphrase)).to.be.equal(
 					expectedAmountOfWhitespaces,
 				);
 			});
@@ -114,7 +114,7 @@ describe('passphrase validation', () => {
 				'\fmodel actor shallow eight glue upper seat lobster reason label enlist bridge';
 
 			it('should return the expected amount of whitespaces', () => {
-				return countPassphraseWhitespaces(passphrase).should.be.equal(
+				return expect(countPassphraseWhitespaces(passphrase)).to.be.equal(
 					expectedAmountOfWhitespaces,
 				);
 			});
@@ -126,7 +126,7 @@ describe('passphrase validation', () => {
 				'\u00A0model actor shallow eight glue upper seat lobster reason label enlist bridge';
 
 			it('should return the expected amount of whitespaces', () => {
-				return countPassphraseWhitespaces(passphrase).should.be.equal(
+				return expect(countPassphraseWhitespaces(passphrase)).to.be.equal(
 					expectedAmountOfWhitespaces,
 				);
 			});
@@ -138,7 +138,7 @@ describe('passphrase validation', () => {
 				'\uFEFFmodel actor shallow eight glue upper seat lobster reason label enlist bridge';
 
 			it('should return the expected amount of whitespaces', () => {
-				return countPassphraseWhitespaces(passphrase).should.be.equal(
+				return expect(countPassphraseWhitespaces(passphrase)).to.be.equal(
 					expectedAmountOfWhitespaces,
 				);
 			});
@@ -150,7 +150,7 @@ describe('passphrase validation', () => {
 				'modelactorshalloweightglueupperseatlobsterreasonlabelenlistbridge';
 
 			it('should return the expected amount of whitespaces', () => {
-				return countPassphraseWhitespaces(passphrase).should.be.equal(
+				return expect(countPassphraseWhitespaces(passphrase)).to.be.equal(
 					expectedAmountOfWhitespaces,
 				);
 			});
@@ -164,7 +164,7 @@ describe('passphrase validation', () => {
 				'model actor shallow eight glue upper seat lobster reason label enlist bridge';
 
 			it('should return the amount of words', () => {
-				return countPassphraseWords(passphrase).should.be.equal(
+				return expect(countPassphraseWords(passphrase)).to.be.equal(
 					expectedAmountOfWords,
 				);
 			});
@@ -176,7 +176,7 @@ describe('passphrase validation', () => {
 				'model actor shallow eight glue upper seat lobster reason label enlist bridge model';
 
 			it('should return the amount of words', () => {
-				return countPassphraseWords(passphrase).should.be.equal(
+				return expect(countPassphraseWords(passphrase)).to.be.equal(
 					expectedAmountOfWords,
 				);
 			});
@@ -188,7 +188,7 @@ describe('passphrase validation', () => {
 				'model actor shallow eight glue upper seat lobster reason';
 
 			it('should return the amount of words', () => {
-				return countPassphraseWords(passphrase).should.be.equal(
+				return expect(countPassphraseWords(passphrase)).to.be.equal(
 					expectedAmountOfWords,
 				);
 			});
@@ -200,7 +200,7 @@ describe('passphrase validation', () => {
 				'model  actor  shallow  eight glue upper seat lobster reason label enlist bridge';
 
 			it('should ignore the whitespaces and return the amount of words', () => {
-				return countPassphraseWords(passphrase).should.be.equal(
+				return expect(countPassphraseWords(passphrase)).to.be.equal(
 					expectedAmountOfWords,
 				);
 			});
@@ -211,7 +211,7 @@ describe('passphrase validation', () => {
 			const passphrase = '     ';
 
 			it('should ignore the whitespaces and return the amount of words', () => {
-				return countPassphraseWords(passphrase).should.be.equal(
+				return expect(countPassphraseWords(passphrase)).to.be.equal(
 					expectedAmountOfWords,
 				);
 			});
@@ -222,7 +222,7 @@ describe('passphrase validation', () => {
 			const passphrase = '';
 
 			it('should return the amount of words', () => {
-				return countPassphraseWords(passphrase).should.be.equal(
+				return expect(countPassphraseWords(passphrase)).to.be.equal(
 					expectedAmountOfWords,
 				);
 			});
@@ -237,7 +237,7 @@ describe('passphrase validation', () => {
 
 			it('should return the number of uppercase characters', () => {
 				const uppercased = countUppercaseCharacters(passphrase);
-				return uppercased.should.be.equal(expectedAmountUppercaseCharacter);
+				return expect(uppercased).to.be.equal(expectedAmountUppercaseCharacter);
 			});
 		});
 
@@ -248,7 +248,9 @@ describe('passphrase validation', () => {
 
 			it('should return the amount of uppercase character', () => {
 				const uppercased = countUppercaseCharacters(passphrase);
-				return uppercased.should.be.equal(expectedAmountOfCapitalCharacters);
+				return expect(uppercased).to.be.equal(
+					expectedAmountOfCapitalCharacters,
+				);
 			});
 		});
 
@@ -258,7 +260,7 @@ describe('passphrase validation', () => {
 				'MODEL ACTOR SHALLOW EIGHT GLUE UPPER SEAT LOBSTER REASON LABEL ENLIST BRIDGE';
 
 			it('should return the amount of uppercase character', () => {
-				return countUppercaseCharacters(passphrase).should.be.equal(
+				return expect(countUppercaseCharacters(passphrase)).to.be.equal(
 					expectedAmountOfCapitalCharacters,
 				);
 			});
@@ -270,7 +272,7 @@ describe('passphrase validation', () => {
 		describe('given a string without uppercase character', () => {
 			const string = 'a string without uppercase character';
 			it('should return an empty array', () => {
-				return locateUppercaseCharacters(string).should.be.eql(emptyArray);
+				return expect(locateUppercaseCharacters(string)).to.be.eql(emptyArray);
 			});
 		});
 
@@ -278,7 +280,7 @@ describe('passphrase validation', () => {
 			const string = 'a String with SOME uppercase characteR';
 			const uppercaseCharacters = [2, 14, 15, 16, 17, 37];
 			it('should return the array with the location of the uppercase character', () => {
-				return locateUppercaseCharacters(string).should.be.eql(
+				return expect(locateUppercaseCharacters(string)).to.be.eql(
 					uppercaseCharacters,
 				);
 			});
@@ -290,14 +292,14 @@ describe('passphrase validation', () => {
 		describe('given a string without whitespaces', () => {
 			const string = 'abcdefghijklkmnop';
 			it('should return an empty array', () => {
-				return locateWhitespaces(string).should.be.eql(emptyArray);
+				return expect(locateWhitespaces(string)).to.be.eql(emptyArray);
 			});
 		});
 
 		describe('given a string with whitespaces', () => {
 			const string = 'abc defghijk lkmnop';
 			it('should return an empty array', () => {
-				return locateWhitespaces(string).should.be.eql(emptyArray);
+				return expect(locateWhitespaces(string)).to.be.eql(emptyArray);
 			});
 		});
 
@@ -305,7 +307,7 @@ describe('passphrase validation', () => {
 			const string = ' abc defghijk lkmnop';
 			const expectedWhitespaceLocation = [0];
 			it('should return the array with the location of the whitespace', () => {
-				return locateWhitespaces(string).should.be.eql(
+				return expect(locateWhitespaces(string)).to.be.eql(
 					expectedWhitespaceLocation,
 				);
 			});
@@ -315,7 +317,7 @@ describe('passphrase validation', () => {
 			const string = 'abc defghijk lkmnop ';
 			const expectedWhitespaceLocation = [19];
 			it('should return the array with the location of the whitespace', () => {
-				return locateWhitespaces(string).should.be.eql(
+				return expect(locateWhitespaces(string)).to.be.eql(
 					expectedWhitespaceLocation,
 				);
 			});
@@ -325,7 +327,7 @@ describe('passphrase validation', () => {
 			const string = 'abc  defghijk  lkmnop ';
 			const expectedWhitespaceLocation = [4, 14, 21];
 			it('should return the array with the location of the whitespaces', () => {
-				return locateWhitespaces(string).should.be.eql(
+				return expect(locateWhitespaces(string)).to.be.eql(
 					expectedWhitespaceLocation,
 				);
 			});
@@ -335,7 +337,7 @@ describe('passphrase validation', () => {
 			const string = 'abc  defghijk\t \nlkmnop \u00A0';
 			const expectedWhitespaceLocation = [4, 14, 15, 23];
 			it('should return the array with the location of the whitespaces', () => {
-				return locateWhitespaces(string).should.be.eql(
+				return expect(locateWhitespaces(string)).to.be.eql(
 					expectedWhitespaceLocation,
 				);
 			});
@@ -350,7 +352,7 @@ describe('passphrase validation', () => {
 				'model actor shallow eight glue upper seat lobster reason label enlist bridge';
 
 			it('should return an empty array', () => {
-				return getPassphraseValidationErrors(passphrase).should.be.eql(
+				return expect(getPassphraseValidationErrors(passphrase)).to.be.eql(
 					emptyErrorArray,
 				);
 			});
@@ -386,7 +388,7 @@ describe('passphrase validation', () => {
 			];
 
 			it('should return the array with the errors', () => {
-				return getPassphraseValidationErrors(passphrase).should.be.eql(
+				return expect(getPassphraseValidationErrors(passphrase)).to.be.eql(
 					passphraseTooManyWordsErrors,
 				);
 			});
@@ -413,7 +415,7 @@ describe('passphrase validation', () => {
 			];
 
 			it('should return the array with the errors', () => {
-				return getPassphraseValidationErrors(passphrase).should.be.eql(
+				return expect(getPassphraseValidationErrors(passphrase)).to.be.eql(
 					passphraseTooFewWordsErrors,
 				);
 			});
@@ -441,7 +443,7 @@ describe('passphrase validation', () => {
 			];
 
 			it('should return the array with the errors', () => {
-				return getPassphraseValidationErrors(passphrase).should.be.eql(
+				return expect(getPassphraseValidationErrors(passphrase)).to.be.eql(
 					passphraseInvalidMnemonicErrors,
 				);
 			});
@@ -469,7 +471,7 @@ describe('passphrase validation', () => {
 			];
 
 			it('should return the array with the errors', () => {
-				return getPassphraseValidationErrors(passphrase).should.be.eql(
+				return expect(getPassphraseValidationErrors(passphrase)).to.be.eql(
 					passphraseInvalidMnemonicErrors,
 				);
 			});
@@ -497,7 +499,7 @@ describe('passphrase validation', () => {
 			];
 
 			it('should return the array with the errors', () => {
-				return getPassphraseValidationErrors(passphrase).should.be.eql(
+				return expect(getPassphraseValidationErrors(passphrase)).to.be.eql(
 					passphraseInvalidMnemonicErrors,
 				);
 			});
@@ -525,7 +527,7 @@ describe('passphrase validation', () => {
 			];
 
 			it('should return the array with the errors', () => {
-				return getPassphraseValidationErrors(passphrase).should.be.eql(
+				return expect(getPassphraseValidationErrors(passphrase)).to.be.eql(
 					passphraseWithUppercaseCharacterErrors,
 				);
 			});
@@ -545,7 +547,7 @@ describe('passphrase validation', () => {
 			];
 
 			it('should return the array with the error', () => {
-				return getPassphraseValidationErrors(passphrase).should.be.eql(
+				return expect(getPassphraseValidationErrors(passphrase)).to.be.eql(
 					passphraseInvalidMnemonicError,
 				);
 			});
@@ -557,10 +559,9 @@ describe('passphrase validation', () => {
 				'model actor shallow eight glue upper seat lobster reason label enlist bridge';
 
 			it('should return an empty array', () => {
-				return getPassphraseValidationErrors(
-					passphrase,
-					wordlist,
-				).should.be.eql(emptyErrorArray);
+				return expect(
+					getPassphraseValidationErrors(passphrase, wordlist),
+				).to.be.eql(emptyErrorArray);
 			});
 		});
 
@@ -579,10 +580,9 @@ describe('passphrase validation', () => {
 			];
 
 			it('should return the array with the error', () => {
-				return getPassphraseValidationErrors(
-					passphrase,
-					wordlist,
-				).should.be.eql(passphraseInvalidMnemonicError);
+				return expect(
+					getPassphraseValidationErrors(passphrase, wordlist),
+				).to.be.eql(passphraseInvalidMnemonicError);
 			});
 		});
 	});

--- a/test/setup.js
+++ b/test/setup.js
@@ -14,7 +14,7 @@
  */
 import sinon from 'sinon';
 import chai, { Assertion } from 'chai';
-import 'chai/register-should';
+import 'chai/register-expect';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
 import naclFactory from 'js-nacl';

--- a/test/transactions/0_transfer.js
+++ b/test/transactions/0_transfer.js
@@ -52,11 +52,11 @@ describe('#transfer transaction', () => {
 			});
 
 			it('should create a transfer transaction', () => {
-				return transferTransaction.should.be.ok;
+				return expect(transferTransaction).to.be.ok;
 			});
 
 			it('should use time.getTimeWithOffset to calculate the timestamp', () => {
-				return getTimeWithOffsetStub.should.be.calledWithExactly(undefined);
+				return expect(getTimeWithOffsetStub).to.be.calledWithExactly(undefined);
 			});
 
 			it('should use time.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
@@ -68,73 +68,75 @@ describe('#transfer transaction', () => {
 					timeOffset: offset,
 				});
 
-				return getTimeWithOffsetStub.should.be.calledWithExactly(offset);
+				return expect(getTimeWithOffsetStub).to.be.calledWithExactly(offset);
 			});
 
 			it('should be an object', () => {
-				return transferTransaction.should.be.an('object');
+				return expect(transferTransaction).to.be.an('object');
 			});
 
 			it('should have id string', () => {
-				return transferTransaction.should.have
-					.property('id')
+				return expect(transferTransaction)
+					.to.have.property('id')
 					.and.be.a('string');
 			});
 
 			it('should have type number equal to 0', () => {
-				return transferTransaction.should.have
-					.property('type')
+				return expect(transferTransaction)
+					.to.have.property('type')
 					.and.be.a('number')
 					.and.equal(transactionType);
 			});
 
 			it('should have amount string equal to provided amount', () => {
-				return transferTransaction.should.have
-					.property('amount')
+				return expect(transferTransaction)
+					.to.have.property('amount')
 					.and.be.a('string')
 					.and.equal(amount);
 			});
 
 			it('should have fee string equal to transfer fee', () => {
-				return transferTransaction.should.have
-					.property('fee')
+				return expect(transferTransaction)
+					.to.have.property('fee')
 					.and.be.a('string')
 					.and.equal(fee);
 			});
 
 			it('should have recipientId string equal to provided recipient id', () => {
-				return transferTransaction.should.have
-					.property('recipientId')
+				return expect(transferTransaction)
+					.to.have.property('recipientId')
 					.and.be.a('string')
 					.and.equal(recipientId);
 			});
 
 			it('should have senderPublicKey hex string equal to sender public key', () => {
-				return transferTransaction.should.have
-					.property('senderPublicKey')
+				return expect(transferTransaction)
+					.to.have.property('senderPublicKey')
 					.and.be.hexString.and.equal(publicKey);
 			});
 
 			it('should have timestamp number equal to result of time.getTimeWithOffset', () => {
-				return transferTransaction.should.have
-					.property('timestamp')
+				return expect(transferTransaction)
+					.to.have.property('timestamp')
 					.and.be.a('number')
 					.and.equal(timeWithOffset);
 			});
 
 			it('should have signature hex string', () => {
-				return transferTransaction.should.have.property('signature').and.be
+				return expect(transferTransaction).to.have.property('signature').and.be
 					.hexString;
 			});
 
 			it('should have an empty asset object', () => {
-				return transferTransaction.should.have
-					.property('asset')
+				return expect(transferTransaction)
+					.to.have.property('asset')
 					.and.be.an('object').and.be.empty;
 			});
 
 			it('should not have the second signature property', () => {
-				return transferTransaction.should.not.have.property('signSignature');
+				return expect(transferTransaction).not.to.have.property(
+					'signSignature',
+				);
 			});
 		});
 
@@ -150,29 +152,29 @@ describe('#transfer transaction', () => {
 			});
 
 			it('should handle invalid (non-utf8 string) data', () => {
-				return transfer
-					.bind(null, {
+				return expect(
+					transfer.bind(null, {
 						recipientId,
 						amount,
 						passphrase,
 						data: Buffer.from('hello'),
-					})
-					.should.throw(
-						'Invalid encoding in transaction data. Data must be utf-8 encoded.',
-					);
+					}),
+				).to.throw(
+					'Invalid encoding in transaction data. Data must be utf-8 encoded.',
+				);
 			});
 
 			it('should have fee string equal to transfer with data fee', () => {
-				return transferTransaction.should.have
-					.property('fee')
+				return expect(transferTransaction)
+					.to.have.property('fee')
 					.and.be.a('string')
 					.and.equal(feeWithData);
 			});
 
 			describe('data asset', () => {
 				it('should be a string equal to provided data', () => {
-					return transferTransaction.asset.should.have
-						.property('data')
+					return expect(transferTransaction.asset)
+						.to.have.property('data')
 						.and.be.a('string')
 						.and.equal(testData);
 				});
@@ -200,12 +202,12 @@ describe('#transfer transaction', () => {
 				data: testData,
 			});
 
-			return transferTransaction.asset.should.have.property('data');
+			return expect(transferTransaction.asset).to.have.property('data');
 		});
 
 		it('should have the second signature property as hex string', () => {
-			return transferTransaction.should.have.property('signSignature').and.be
-				.hexString;
+			return expect(transferTransaction).to.have.property('signSignature').and
+				.be.hexString;
 		});
 	});
 
@@ -220,45 +222,49 @@ describe('#transfer transaction', () => {
 			});
 
 			it('should have the type', () => {
-				return transferTransaction.should.have
-					.property('type')
+				return expect(transferTransaction)
+					.to.have.property('type')
 					.equal(transactionType);
 			});
 
 			it('should have the amount', () => {
-				return transferTransaction.should.have.property('amount').equal(amount);
+				return expect(transferTransaction)
+					.to.have.property('amount')
+					.equal(amount);
 			});
 
 			it('should have the fee', () => {
-				return transferTransaction.should.have.property('fee').equal(fee);
+				return expect(transferTransaction)
+					.to.have.property('fee')
+					.equal(fee);
 			});
 
 			it('should have the recipient', () => {
-				return transferTransaction.should.have
-					.property('recipientId')
+				return expect(transferTransaction)
+					.to.have.property('recipientId')
 					.equal(recipientId);
 			});
 
 			it('should have the sender public key', () => {
-				return transferTransaction.should.have
-					.property('senderPublicKey')
+				return expect(transferTransaction)
+					.to.have.property('senderPublicKey')
 					.equal(null);
 			});
 
 			it('should have the timestamp', () => {
-				return transferTransaction.should.have.property('timestamp');
+				return expect(transferTransaction).to.have.property('timestamp');
 			});
 
 			it('should have the asset ', () => {
-				return transferTransaction.should.have.property('asset');
+				return expect(transferTransaction).to.have.property('asset');
 			});
 
 			it('should not have the signature', () => {
-				return transferTransaction.should.not.have.property('signature');
+				return expect(transferTransaction).not.to.have.property('signature');
 			});
 
 			it('should not have the id', () => {
-				return transferTransaction.should.not.have.property('id');
+				return expect(transferTransaction).not.to.have.property('id');
 			});
 		});
 	});

--- a/test/transactions/1_register_second_passphrase.js
+++ b/test/transactions/1_register_second_passphrase.js
@@ -47,11 +47,11 @@ describe('#registerSecondPassphrase transaction', () => {
 	});
 
 	it('should create a register second passphrase transaction', () => {
-		return registerSecondPassphraseTransaction.should.be.ok;
+		return expect(registerSecondPassphraseTransaction).to.be.ok;
 	});
 
 	it('should use time.getTimeWithOffset to calculate the timestamp', () => {
-		return getTimeWithOffsetStub.should.be.calledWithExactly(undefined);
+		return expect(getTimeWithOffsetStub).to.be.calledWithExactly(undefined);
 	});
 
 	it('should use time.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
@@ -62,97 +62,100 @@ describe('#registerSecondPassphrase transaction', () => {
 			timeOffset: offset,
 		});
 
-		return getTimeWithOffsetStub.should.be.calledWithExactly(offset);
+		return expect(getTimeWithOffsetStub).to.be.calledWithExactly(offset);
 	});
 
 	describe('returned register second passphrase transaction', () => {
 		it('should be an object', () => {
-			return registerSecondPassphraseTransaction.should.be.an('object');
+			return expect(registerSecondPassphraseTransaction).to.be.an('object');
 		});
 
 		it('should have an id string', () => {
-			return registerSecondPassphraseTransaction.should.have
-				.property('id')
+			return expect(registerSecondPassphraseTransaction)
+				.to.have.property('id')
 				.and.be.a('string');
 		});
 
 		it('should have type number equal to 1', () => {
-			return registerSecondPassphraseTransaction.should.have
-				.property('type')
+			return expect(registerSecondPassphraseTransaction)
+				.to.have.property('type')
 				.and.be.a('number')
 				.and.equal(transactionType);
 		});
 
 		it('should have amount string equal to 0', () => {
-			return registerSecondPassphraseTransaction.should.have
-				.property('amount')
+			return expect(registerSecondPassphraseTransaction)
+				.to.have.property('amount')
 				.and.be.a('string')
 				.and.equal(amount);
 		});
 
 		it('should have fee string equal to second passphrase fee', () => {
-			return registerSecondPassphraseTransaction.should.have
-				.property('fee')
+			return expect(registerSecondPassphraseTransaction)
+				.to.have.property('fee')
 				.and.be.a('string')
 				.and.equal(secondPassphraseFee);
 		});
 
 		it('should have recipientId equal to null', () => {
-			return registerSecondPassphraseTransaction.should.have.property(
+			return expect(registerSecondPassphraseTransaction).to.have.property(
 				'recipientId',
 			).and.be.null;
 		});
 
 		it('should have senderPublicKey hex string equal to sender public key', () => {
-			return registerSecondPassphraseTransaction.should.have
-				.property('senderPublicKey')
+			return expect(registerSecondPassphraseTransaction)
+				.to.have.property('senderPublicKey')
 				.and.be.hexString.and.equal(publicKey);
 		});
 
 		it('should have timestamp number equal to result of time.getTimeWithOffset', () => {
-			return registerSecondPassphraseTransaction.should.have
-				.property('timestamp')
+			return expect(registerSecondPassphraseTransaction)
+				.to.have.property('timestamp')
 				.and.be.a('number')
 				.and.equal(timeWithOffset);
 		});
 
 		it('should have signature hex string', () => {
-			return registerSecondPassphraseTransaction.should.have.property(
+			return expect(registerSecondPassphraseTransaction).to.have.property(
 				'signature',
 			).and.be.hexString;
 		});
 
 		it('should have asset object', () => {
-			return registerSecondPassphraseTransaction.should.have.property('asset')
-				.and.not.be.empty;
+			return expect(registerSecondPassphraseTransaction).to.have.property(
+				'asset',
+			).and.not.be.empty;
 		});
 
 		it('should not have a signSignature property', () => {
-			return registerSecondPassphraseTransaction.should.not.have.property(
+			return expect(registerSecondPassphraseTransaction).not.to.have.property(
 				'signSignature',
 			);
 		});
 
 		describe('signature asset', () => {
 			it('should be an object', () => {
-				return registerSecondPassphraseTransaction.asset.should.have
-					.property('signature')
+				return expect(registerSecondPassphraseTransaction.asset)
+					.to.have.property('signature')
 					.and.be.an('object').and.not.be.empty;
 			});
 
 			it('should have a 32-byte publicKey hex string', () => {
-				registerSecondPassphraseTransaction.asset.should.have
-					.property('signature')
+				expect(registerSecondPassphraseTransaction.asset)
+					.to.have.property('signature')
 					.with.property('publicKey').and.be.hexString;
-				return Buffer.from(
-					registerSecondPassphraseTransaction.asset.signature.publicKey,
-					'hex',
-				).should.have.length(32);
+				return expect(
+					Buffer.from(
+						registerSecondPassphraseTransaction.asset.signature.publicKey,
+						'hex',
+					),
+				).to.have.length(32);
 			});
 
 			it('should have a publicKey equal to the public key for the provided second passphrase', () => {
-				return registerSecondPassphraseTransaction.asset.should.have
-					.property('signature')
+				return expect(registerSecondPassphraseTransaction.asset)
+					.to.have.property('signature')
 					.with.property('publicKey')
 					.and.equal(secondPublicKey);
 			});
@@ -162,9 +165,9 @@ describe('#registerSecondPassphrase transaction', () => {
 					passphrase,
 					secondPassphrase: '',
 				});
-				return registerSecondPassphraseTransaction.asset.signature.publicKey.should.be.equal(
-					emptyStringPublicKey,
-				);
+				return expect(
+					registerSecondPassphraseTransaction.asset.signature.publicKey,
+				).to.be.equal(emptyStringPublicKey);
 			});
 		});
 	});
@@ -179,57 +182,57 @@ describe('#registerSecondPassphrase transaction', () => {
 			});
 
 			it('should have the type', () => {
-				return registerSecondPassphraseTransaction.should.have
-					.property('type')
+				return expect(registerSecondPassphraseTransaction)
+					.to.have.property('type')
 					.equal(transactionType);
 			});
 
 			it('should have the amount', () => {
-				return registerSecondPassphraseTransaction.should.have
-					.property('amount')
+				return expect(registerSecondPassphraseTransaction)
+					.to.have.property('amount')
 					.equal(amount);
 			});
 
 			it('should have the fee', () => {
-				return registerSecondPassphraseTransaction.should.have
-					.property('fee')
+				return expect(registerSecondPassphraseTransaction)
+					.to.have.property('fee')
 					.equal(fee);
 			});
 
 			it('should have the recipient', () => {
-				return registerSecondPassphraseTransaction.should.have
-					.property('recipientId')
+				return expect(registerSecondPassphraseTransaction)
+					.to.have.property('recipientId')
 					.equal(null);
 			});
 
 			it('should have the sender public key', () => {
-				return registerSecondPassphraseTransaction.should.have
-					.property('senderPublicKey')
+				return expect(registerSecondPassphraseTransaction)
+					.to.have.property('senderPublicKey')
 					.equal(null);
 			});
 
 			it('should have the timestamp', () => {
-				return registerSecondPassphraseTransaction.should.have.property(
+				return expect(registerSecondPassphraseTransaction).to.have.property(
 					'timestamp',
 				);
 			});
 
 			it('should have the asset with the signature with the public key', () => {
-				return registerSecondPassphraseTransaction.should.have
-					.property('asset')
+				return expect(registerSecondPassphraseTransaction)
+					.to.have.property('asset')
 					.with.property('signature')
 					.with.property('publicKey')
 					.of.a('string');
 			});
 
 			it('should not have the signature', () => {
-				return registerSecondPassphraseTransaction.should.not.have.property(
+				return expect(registerSecondPassphraseTransaction).not.to.have.property(
 					'signature',
 				);
 			});
 
 			it('should not have the id', () => {
-				return registerSecondPassphraseTransaction.should.not.have.property(
+				return expect(registerSecondPassphraseTransaction).not.to.have.property(
 					'id',
 				);
 			});

--- a/test/transactions/2_register_delegate.js
+++ b/test/transactions/2_register_delegate.js
@@ -48,95 +48,95 @@ describe('#registerDelegate transaction', () => {
 		});
 
 		it('should create a register delegate transaction', () => {
-			return registerDelegateTransaction.should.be.ok;
+			return expect(registerDelegateTransaction).to.be.ok;
 		});
 
 		it('should use time.getTimeWithOffset to calculate the timestamp', () => {
-			return getTimeWithOffsetStub.should.be.calledWithExactly(undefined);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(undefined);
 		});
 
 		it('should use time.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
 			const offset = -10;
 			registerDelegate({ passphrase, username, timeOffset: offset });
 
-			return getTimeWithOffsetStub.should.be.calledWithExactly(offset);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(offset);
 		});
 
 		it('should be an object', () => {
-			return registerDelegateTransaction.should.be.an('object');
+			return expect(registerDelegateTransaction).to.be.an('object');
 		});
 
 		it('should have an id string', () => {
-			return registerDelegateTransaction.should.have
-				.property('id')
+			return expect(registerDelegateTransaction)
+				.to.have.property('id')
 				.and.be.a('string');
 		});
 
 		it('should have type number equal to 2', () => {
-			return registerDelegateTransaction.should.have
-				.property('type')
+			return expect(registerDelegateTransaction)
+				.to.have.property('type')
 				.and.be.a('number')
 				.and.equal(transactionType);
 		});
 
 		it('should have amount string equal to 0', () => {
-			return registerDelegateTransaction.should.have
-				.property('amount')
+			return expect(registerDelegateTransaction)
+				.to.have.property('amount')
 				.and.be.a('string')
 				.and.equal(amount);
 		});
 
 		it('should have fee string equal to 25 LSK', () => {
-			return registerDelegateTransaction.should.have
-				.property('fee')
+			return expect(registerDelegateTransaction)
+				.to.have.property('fee')
 				.and.be.a('string')
 				.and.equal(fee);
 		});
 
 		it('should have recipientId equal to null', () => {
-			return registerDelegateTransaction.should.have.property('recipientId').and
-				.be.null;
+			return expect(registerDelegateTransaction).to.have.property('recipientId')
+				.and.be.null;
 		});
 
 		it('should have senderPublicKey hex string equal to sender public key', () => {
-			return registerDelegateTransaction.should.have
-				.property('senderPublicKey')
+			return expect(registerDelegateTransaction)
+				.to.have.property('senderPublicKey')
 				.and.be.hexString.and.equal(publicKey);
 		});
 
 		it('should have timestamp number equal to result of time.getTimeWithOffset', () => {
-			return registerDelegateTransaction.should.have
-				.property('timestamp')
+			return expect(registerDelegateTransaction)
+				.to.have.property('timestamp')
 				.and.be.a('number')
 				.and.equal(timeWithOffset);
 		});
 
 		it('should have signature hex string', () => {
-			return registerDelegateTransaction.should.have.property('signature').and
-				.be.hexString;
+			return expect(registerDelegateTransaction).to.have.property('signature')
+				.and.be.hexString;
 		});
 
 		it('should not have the second signature property', () => {
-			return registerDelegateTransaction.should.not.have.property(
+			return expect(registerDelegateTransaction).not.to.have.property(
 				'signSignature',
 			);
 		});
 
 		it('should have asset', () => {
-			return registerDelegateTransaction.should.have.property('asset').and.not
-				.be.empty;
+			return expect(registerDelegateTransaction).to.have.property('asset').and
+				.not.be.empty;
 		});
 
 		describe('delegate asset', () => {
 			it('should be an object', () => {
-				return registerDelegateTransaction.asset.should.have
-					.property('delegate')
+				return expect(registerDelegateTransaction.asset)
+					.to.have.property('delegate')
 					.and.be.an('object');
 			});
 
 			it('should have the provided username as a string', () => {
-				return registerDelegateTransaction.asset.delegate.should.have
-					.property('username')
+				return expect(registerDelegateTransaction.asset.delegate)
+					.to.have.property('username')
 					.and.be.a('string')
 					.and.equal(username);
 			});
@@ -154,8 +154,9 @@ describe('#registerDelegate transaction', () => {
 		});
 
 		it('should have the second signature property as hex string', () => {
-			return registerDelegateTransaction.should.have.property('signSignature')
-				.and.be.hexString;
+			return expect(registerDelegateTransaction).to.have.property(
+				'signSignature',
+			).and.be.hexString;
 		});
 	});
 
@@ -169,54 +170,56 @@ describe('#registerDelegate transaction', () => {
 			});
 
 			it('should have the type', () => {
-				return registerDelegateTransaction.should.have
-					.property('type')
+				return expect(registerDelegateTransaction)
+					.to.have.property('type')
 					.equal(transactionType);
 			});
 
 			it('should have the amount', () => {
-				return registerDelegateTransaction.should.have
-					.property('amount')
+				return expect(registerDelegateTransaction)
+					.to.have.property('amount')
 					.equal(amount);
 			});
 
 			it('should have the fee', () => {
-				return registerDelegateTransaction.should.have
-					.property('fee')
+				return expect(registerDelegateTransaction)
+					.to.have.property('fee')
 					.equal(fee);
 			});
 
 			it('should have the recipient id', () => {
-				return registerDelegateTransaction.should.have
-					.property('recipientId')
+				return expect(registerDelegateTransaction)
+					.to.have.property('recipientId')
 					.equal(null);
 			});
 
 			it('should have the sender public key', () => {
-				return registerDelegateTransaction.should.have
-					.property('senderPublicKey')
+				return expect(registerDelegateTransaction)
+					.to.have.property('senderPublicKey')
 					.equal(null);
 			});
 
 			it('should have the timestamp', () => {
-				return registerDelegateTransaction.should.have.property('timestamp');
+				return expect(registerDelegateTransaction).to.have.property(
+					'timestamp',
+				);
 			});
 
 			it('should have the asset with the delegate', () => {
-				return registerDelegateTransaction.should.have
-					.property('asset')
+				return expect(registerDelegateTransaction)
+					.to.have.property('asset')
 					.with.property('delegate')
 					.with.property('username');
 			});
 
 			it('should not have the signature', () => {
-				return registerDelegateTransaction.should.not.have.property(
+				return expect(registerDelegateTransaction).not.to.have.property(
 					'signature',
 				);
 			});
 
 			it('should not have the id', () => {
-				return registerDelegateTransaction.should.not.have.property('id');
+				return expect(registerDelegateTransaction).not.to.have.property('id');
 			});
 		});
 	});

--- a/test/transactions/3_cast_votes.js
+++ b/test/transactions/3_cast_votes.js
@@ -60,100 +60,104 @@ describe('#castVotes transaction', () => {
 		});
 
 		it('should create a cast votes transaction', () => {
-			return castVotesTransaction.should.be.ok;
+			return expect(castVotesTransaction).to.be.ok;
 		});
 
 		it('should use time.getTimeWithOffset to calculate the timestamp', () => {
-			return getTimeWithOffsetStub.should.be.calledWithExactly(undefined);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(undefined);
 		});
 
 		it('should use time.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
 			const offset = -10;
 			castVotes({ passphrase, votes: votePublicKeys, timeOffset: offset });
 
-			return getTimeWithOffsetStub.should.be.calledWithExactly(offset);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(offset);
 		});
 
 		describe('the returned cast votes transaction', () => {
 			it('should be an object', () => {
-				return castVotesTransaction.should.be.an('object');
+				return expect(castVotesTransaction).to.be.an('object');
 			});
 
 			it('should have id string', () => {
-				return castVotesTransaction.should.have
-					.property('id')
+				return expect(castVotesTransaction)
+					.to.have.property('id')
 					.and.be.a('string');
 			});
 
 			it('should have type number equal to 3', () => {
-				return castVotesTransaction.should.have
-					.property('type')
+				return expect(castVotesTransaction)
+					.to.have.property('type')
 					.and.be.a('number')
 					.and.equal(transactionType);
 			});
 
 			it('should have amount string equal to 0', () => {
-				return castVotesTransaction.should.have
-					.property('amount')
+				return expect(castVotesTransaction)
+					.to.have.property('amount')
 					.and.be.a('string')
 					.and.equal(amount);
 			});
 
 			it('should have fee string equal to 100000000', () => {
-				return castVotesTransaction.should.have
-					.property('fee')
+				return expect(castVotesTransaction)
+					.to.have.property('fee')
 					.and.be.a('string')
 					.and.equal(fee);
 			});
 
 			it('should have recipientId string equal to address', () => {
-				return castVotesTransaction.should.have
-					.property('recipientId')
+				return expect(castVotesTransaction)
+					.to.have.property('recipientId')
 					.and.be.a('string')
 					.and.equal(address);
 			});
 
 			it('should have senderPublicKey hex string equal to sender public key', () => {
-				return castVotesTransaction.should.have
-					.property('senderPublicKey')
+				return expect(castVotesTransaction)
+					.to.have.property('senderPublicKey')
 					.and.be.hexString.and.equal(firstPublicKey);
 			});
 
 			it('should have timestamp number equal to result of time.getTimeWithOffset', () => {
-				return castVotesTransaction.should.have
-					.property('timestamp')
+				return expect(castVotesTransaction)
+					.to.have.property('timestamp')
 					.and.be.a('number')
 					.and.equal(timeWithOffset);
 			});
 
 			it('should have signature hex string', () => {
-				return castVotesTransaction.should.have.property('signature').and.be
+				return expect(castVotesTransaction).to.have.property('signature').and.be
 					.hexString;
 			});
 
 			it('should not have the second signature property', () => {
-				return castVotesTransaction.should.not.have.property('signSignature');
+				return expect(castVotesTransaction).not.to.have.property(
+					'signSignature',
+				);
 			});
 
 			it('should have asset', () => {
-				return castVotesTransaction.should.have.property('asset').and.not.be
+				return expect(castVotesTransaction).to.have.property('asset').and.not.be
 					.empty;
 			});
 
 			describe('votes asset', () => {
 				it('should be array', () => {
-					return castVotesTransaction.asset.should.have
-						.property('votes')
+					return expect(castVotesTransaction.asset)
+						.to.have.property('votes')
 						.and.be.an('array');
 				});
 
 				it('should contain two elements', () => {
-					return castVotesTransaction.asset.votes.should.have.length(2);
+					return expect(castVotesTransaction.asset.votes).to.have.length(2);
 				});
 
 				it('should have a vote for the delegate public key', () => {
 					const expectedArray = [`+${firstPublicKey}`, `+${secondPublicKey}`];
-					return castVotesTransaction.asset.votes.should.be.eql(expectedArray);
+					return expect(castVotesTransaction.asset.votes).to.be.eql(
+						expectedArray,
+					);
 				});
 			});
 		});
@@ -170,8 +174,8 @@ describe('#castVotes transaction', () => {
 		});
 
 		it('should have the second signature property as hex string', () => {
-			return castVotesTransaction.should.have.property('signSignature').and.be
-				.hexString;
+			return expect(castVotesTransaction).to.have.property('signSignature').and
+				.be.hexString;
 		});
 	});
 
@@ -186,8 +190,8 @@ describe('#castVotes transaction', () => {
 		});
 
 		it('the transaction should have the votes as an array', () => {
-			return castVotesTransaction.asset.should.have
-				.property('votes')
+			return expect(castVotesTransaction.asset)
+				.to.have.property('votes')
 				.and.be.an('array');
 		});
 
@@ -198,7 +202,7 @@ describe('#castVotes transaction', () => {
 				`-${thirdPublicKey}`,
 				`-${fourthPublicKey}`,
 			];
-			return castVotesTransaction.asset.votes.should.be.eql(expectedArray);
+			return expect(castVotesTransaction.asset.votes).to.be.eql(expectedArray);
 		});
 	});
 
@@ -212,40 +216,40 @@ describe('#castVotes transaction', () => {
 		});
 
 		it('the transaction should have the votes array', () => {
-			return castVotesTransaction.asset.should.have
-				.property('votes')
+			return expect(castVotesTransaction.asset)
+				.to.have.property('votes')
 				.and.be.an('array');
 		});
 
 		it('the transaction asset should have the unvotes', () => {
 			const expectedArray = [`-${thirdPublicKey}`, `-${fourthPublicKey}`];
-			return castVotesTransaction.asset.votes.should.be.eql(expectedArray);
+			return expect(castVotesTransaction.asset.votes).to.be.eql(expectedArray);
 		});
 	});
 
 	describe('when the cast vote transaction is created with one too short public key', () => {
 		it('should throw an error', () => {
-			return castVotes
-				.bind(null, {
+			return expect(
+				castVotes.bind(null, {
 					passphrase,
 					unvotes: unvotePublicKeys,
 					votes: [tooShortPublicKey],
-				})
-				.should.throw(
-					'Public key d019a4b6fa37e8ebeb64766c7b239d962fb3b3f265b8d3083206097b912cd9 length differs from the expected 32 bytes for a public key.',
-				);
+				}),
+			).to.throw(
+				'Public key d019a4b6fa37e8ebeb64766c7b239d962fb3b3f265b8d3083206097b912cd9 length differs from the expected 32 bytes for a public key.',
+			);
 		});
 	});
 
 	describe('when the cast vote transaction is created with one plus prepended public key', () => {
 		it('should throw an error', () => {
-			return castVotes
-				.bind(null, {
+			return expect(
+				castVotes.bind(null, {
 					passphrase,
 					unvotes: unvotePublicKeys,
 					votes: [plusPrependedPublicKey],
-				})
-				.should.throw('Argument must be a valid hex string.');
+				}),
+			).to.throw('Argument must be a valid hex string.');
 		});
 	});
 
@@ -254,43 +258,43 @@ describe('#castVotes transaction', () => {
 			it('should throw a duplication error', () => {
 				const votes = [firstPublicKey, secondPublicKey];
 				const unvotes = [firstPublicKey, thirdPublicKey];
-				return castVotes
-					.bind(null, {
+				return expect(
+					castVotes.bind(null, {
 						passphrase,
 						unvotes,
 						votes,
-					})
-					.should.throw(
-						'Duplicated public key: 5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09.',
-					);
+					}),
+				).to.throw(
+					'Duplicated public key: 5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09.',
+				);
 			});
 		});
 
 		describe('Given votes with duplication', () => {
 			it('should throw a duplication error for votes', () => {
 				const votes = [firstPublicKey, secondPublicKey, firstPublicKey];
-				return castVotes
-					.bind(null, {
+				return expect(
+					castVotes.bind(null, {
 						passphrase,
 						votes,
-					})
-					.should.throw(
-						'Duplicated public key: 5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09.',
-					);
+					}),
+				).to.throw(
+					'Duplicated public key: 5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09.',
+				);
 			});
 		});
 
 		describe('Given unvotes with duplication', () => {
 			it('should throw a duplication error for unvotes', () => {
 				const unvotes = [firstPublicKey, secondPublicKey, firstPublicKey];
-				return castVotes
-					.bind(null, {
+				return expect(
+					castVotes.bind(null, {
 						passphrase,
 						unvotes,
-					})
-					.should.throw(
-						'Duplicated public key: 5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09.',
-					);
+					}),
+				).to.throw(
+					'Duplicated public key: 5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09.',
+				);
 			});
 		});
 	});
@@ -306,49 +310,51 @@ describe('#castVotes transaction', () => {
 			});
 
 			it('should have the type', () => {
-				return castVotesTransaction.should.have
-					.property('type')
+				return expect(castVotesTransaction)
+					.to.have.property('type')
 					.equal(transactionType);
 			});
 
 			it('should have the amount', () => {
-				return castVotesTransaction.should.have
-					.property('amount')
+				return expect(castVotesTransaction)
+					.to.have.property('amount')
 					.equal(amount);
 			});
 
 			it('should have the fee', () => {
-				return castVotesTransaction.should.have.property('fee').equal(fee);
+				return expect(castVotesTransaction)
+					.to.have.property('fee')
+					.equal(fee);
 			});
 
 			it('should have the recipient id', () => {
-				return castVotesTransaction.should.have
-					.property('recipientId')
+				return expect(castVotesTransaction)
+					.to.have.property('recipientId')
 					.equal(null);
 			});
 
 			it('should have the sender public key', () => {
-				return castVotesTransaction.should.have
-					.property('senderPublicKey')
+				return expect(castVotesTransaction)
+					.to.have.property('senderPublicKey')
 					.equal(null);
 			});
 
 			it('should have the timestamp', () => {
-				return castVotesTransaction.should.have.property('timestamp');
+				return expect(castVotesTransaction).to.have.property('timestamp');
 			});
 
 			it('should have the asset with the votes', () => {
-				return castVotesTransaction.should.have
-					.property('asset')
+				return expect(castVotesTransaction)
+					.to.have.property('asset')
 					.with.property('votes');
 			});
 
 			it('should not have the signature', () => {
-				return castVotesTransaction.should.not.have.property('signature');
+				return expect(castVotesTransaction).not.to.have.property('signature');
 			});
 
 			it('should not have the id', () => {
-				return castVotesTransaction.should.not.have.property('id');
+				return expect(castVotesTransaction).not.to.have.property('id');
 			});
 		});
 	});

--- a/test/transactions/4_register_multisignature_account.js
+++ b/test/transactions/4_register_multisignature_account.js
@@ -69,11 +69,11 @@ describe('#registerMultisignatureAccount transaction', () => {
 		});
 
 		it('should create a register multisignature transaction', () => {
-			return registerMultisignatureTransaction.should.be.ok;
+			return expect(registerMultisignatureTransaction).to.be.ok;
 		});
 
 		it('should use time.getTimeWithOffset to calculate the timestamp', () => {
-			return getTimeWithOffsetStub.should.be.calledWithExactly(undefined);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(undefined);
 		});
 
 		it('should use time.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
@@ -86,94 +86,95 @@ describe('#registerMultisignatureAccount transaction', () => {
 				timeOffset: offset,
 			});
 
-			return getTimeWithOffsetStub.should.be.calledWithExactly(offset);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(offset);
 		});
 
 		describe('returned register multisignature transaction', () => {
 			it('should be an object', () => {
-				return registerMultisignatureTransaction.should.be.an('object');
+				return expect(registerMultisignatureTransaction).to.be.an('object');
 			});
 
 			it('should have id string', () => {
-				return registerMultisignatureTransaction.should.have
-					.property('id')
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('id')
 					.and.be.a('string');
 			});
 
 			it('should have type number equal to 4', () => {
-				return registerMultisignatureTransaction.should.have
-					.property('type')
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('type')
 					.and.be.a('number')
 					.and.equal(transactionType);
 			});
 
 			it('should have amount string equal to 0', () => {
-				return registerMultisignatureTransaction.should.have
-					.property('amount')
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('amount')
 					.and.be.a('string')
 					.and.equal(amount);
 			});
 
 			it('should have fee string equal to 15 LSK', () => {
-				return registerMultisignatureTransaction.should.have
-					.property('fee')
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('fee')
 					.and.be.a('string')
 					.and.equal(fee);
 			});
 
 			it('should have recipientId string equal to null', () => {
-				return registerMultisignatureTransaction.should.have.property(
+				return expect(registerMultisignatureTransaction).to.have.property(
 					'recipientId',
 				).and.be.null;
 			});
 
 			it('should have senderPublicKey hex string equal to sender public key', () => {
-				return registerMultisignatureTransaction.should.have
-					.property('senderPublicKey')
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('senderPublicKey')
 					.and.be.hexString.and.equal(keys.publicKey);
 			});
 
 			it('should have timestamp number equal to result of time.getTimeWithOffset', () => {
-				return registerMultisignatureTransaction.should.have
-					.property('timestamp')
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('timestamp')
 					.and.be.a('number')
 					.and.equal(timeWithOffset);
 			});
 
 			it('should have signature hex string', () => {
-				return registerMultisignatureTransaction.should.have.property(
+				return expect(registerMultisignatureTransaction).to.have.property(
 					'signature',
 				).and.be.hexString;
 			});
 
 			it('should have asset', () => {
-				return registerMultisignatureTransaction.should.have.property('asset')
-					.and.not.be.empty;
+				return expect(registerMultisignatureTransaction).to.have.property(
+					'asset',
+				).and.not.be.empty;
 			});
 
 			it('should not have a second signature', () => {
-				return registerMultisignatureTransaction.should.not.have.property(
+				return expect(registerMultisignatureTransaction).not.to.have.property(
 					'signSignature',
 				);
 			});
 
 			describe('multisignature asset', () => {
 				it('should be object', () => {
-					return registerMultisignatureTransaction.asset.should.have
-						.property('multisignature')
+					return expect(registerMultisignatureTransaction.asset)
+						.to.have.property('multisignature')
 						.and.be.an('object');
 				});
 
 				it('should have a min number equal to provided minimum', () => {
-					return registerMultisignatureTransaction.asset.multisignature.should.have
-						.property('min')
+					return expect(registerMultisignatureTransaction.asset.multisignature)
+						.to.have.property('min')
 						.and.be.a('number')
 						.and.be.equal(minimum);
 				});
 
 				it('should have a lifetime number equal to provided lifetime', () => {
-					return registerMultisignatureTransaction.asset.multisignature.should.have
-						.property('lifetime')
+					return expect(registerMultisignatureTransaction.asset.multisignature)
+						.to.have.property('lifetime')
 						.and.be.a('number')
 						.and.be.equal(lifetime);
 				});
@@ -183,8 +184,8 @@ describe('#registerMultisignatureAccount transaction', () => {
 						'+5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09',
 						'+922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa',
 					];
-					return registerMultisignatureTransaction.asset.multisignature.should.have
-						.property('keysgroup')
+					return expect(registerMultisignatureTransaction.asset.multisignature)
+						.to.have.property('keysgroup')
 						.and.be.eql(expectedArray);
 				});
 			});
@@ -204,7 +205,7 @@ describe('#registerMultisignatureAccount transaction', () => {
 		});
 
 		it('should have the second signature property as hex string', () => {
-			return registerMultisignatureTransaction.should.have.property(
+			return expect(registerMultisignatureTransaction).to.have.property(
 				'signSignature',
 			).and.be.hexString;
 		});
@@ -212,47 +213,45 @@ describe('#registerMultisignatureAccount transaction', () => {
 
 	describe('when the register multisignature account transaction is created with one too short public key', () => {
 		it('should throw an error', () => {
-			return registerMultisignatureAccount
-				.bind(null, {
+			return expect(
+				registerMultisignatureAccount.bind(null, {
 					passphrase,
 					secondPassphrase,
 					keysgroup: tooShortPublicKeyKeysgroup,
 					lifetime,
 					minimum,
-				})
-				.should.throw(
-					'Public key d019a4b6fa37e8ebeb64766c7b239d962fb3b3f265b8d3083206097b912cd9 length differs from the expected 32 bytes for a public key.',
-				);
+				}),
+			).to.throw(
+				'Public key d019a4b6fa37e8ebeb64766c7b239d962fb3b3f265b8d3083206097b912cd9 length differs from the expected 32 bytes for a public key.',
+			);
 		});
 	});
 
 	describe('when the register multisignature account transaction is created with one plus prepended public key', () => {
 		it('should throw an error', () => {
-			return registerMultisignatureAccount
-				.bind(null, {
+			return expect(
+				registerMultisignatureAccount.bind(null, {
 					passphrase,
 					secondPassphrase,
 					keysgroup: plusPrependedPublicKeyKeysgroup,
 					lifetime,
 					minimum,
-				})
-				.should.throw('Argument must be a valid hex string.');
+				}),
+			).to.throw('Argument must be a valid hex string.');
 		});
 	});
 
 	describe('when the register multisignature account transaction is created with one empty keysgroup', () => {
 		it('should throw an error', () => {
-			return registerMultisignatureAccount
-				.bind(null, {
+			return expect(
+				registerMultisignatureAccount.bind(null, {
 					passphrase,
 					secondPassphrase,
 					keysgroup: [],
 					lifetime,
 					minimum,
-				})
-				.should.throw(
-					'Expected between 1 and 16 public keys in the keysgroup.',
-				);
+				}),
+			).to.throw('Expected between 1 and 16 public keys in the keysgroup.');
 		});
 	});
 
@@ -269,17 +268,15 @@ describe('#registerMultisignatureAccount transaction', () => {
 		});
 
 		it('should throw an error', () => {
-			return registerMultisignatureAccount
-				.bind(null, {
+			return expect(
+				registerMultisignatureAccount.bind(null, {
 					passphrase,
 					secondPassphrase,
 					keysgroup,
 					lifetime,
 					minimum,
-				})
-				.should.throw(
-					'Expected between 1 and 16 public keys in the keysgroup.',
-				);
+				}),
+			).to.throw('Expected between 1 and 16 public keys in the keysgroup.');
 		});
 	});
 
@@ -290,17 +287,17 @@ describe('#registerMultisignatureAccount transaction', () => {
 		});
 
 		it('should throw an error', () => {
-			return registerMultisignatureAccount
-				.bind(null, {
+			return expect(
+				registerMultisignatureAccount.bind(null, {
 					passphrase,
 					secondPassphrase,
 					keysgroup,
 					lifetime,
 					minimum,
-				})
-				.should.throw(
-					'Duplicated public key: 5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09.',
-				);
+				}),
+			).to.throw(
+				'Duplicated public key: 5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09.',
+			);
 		});
 	});
 
@@ -316,55 +313,57 @@ describe('#registerMultisignatureAccount transaction', () => {
 			});
 
 			it('should have the type', () => {
-				return registerMultisignatureTransaction.should.have
-					.property('type')
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('type')
 					.equal(transactionType);
 			});
 
 			it('should have the amount', () => {
-				return registerMultisignatureTransaction.should.have
-					.property('amount')
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('amount')
 					.equal(amount);
 			});
 
 			it('should have the fee', () => {
-				return registerMultisignatureTransaction.should.have
-					.property('fee')
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('fee')
 					.equal(fee);
 			});
 
 			it('should have the recipient id', () => {
-				return registerMultisignatureTransaction.should.have
-					.property('recipientId')
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('recipientId')
 					.equal(null);
 			});
 
 			it('should have the sender public key', () => {
-				return registerMultisignatureTransaction.should.have
-					.property('senderPublicKey')
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('senderPublicKey')
 					.equal(null);
 			});
 
 			it('should have the timestamp', () => {
-				return registerMultisignatureTransaction.should.have.property(
+				return expect(registerMultisignatureTransaction).to.have.property(
 					'timestamp',
 				);
 			});
 
 			it('should have the asset with the multisignature with the min, lifetime and keysgroup', () => {
-				return registerMultisignatureTransaction.should.have.nested
-					.property('asset.multisignature')
+				return expect(registerMultisignatureTransaction)
+					.to.have.nested.property('asset.multisignature')
 					.with.all.keys('min', 'lifetime', 'keysgroup');
 			});
 
 			it('should not have the signature', () => {
-				return registerMultisignatureTransaction.should.not.have.property(
+				return expect(registerMultisignatureTransaction).not.to.have.property(
 					'signature',
 				);
 			});
 
 			it('should not have the id', () => {
-				return registerMultisignatureTransaction.should.not.have.property('id');
+				return expect(registerMultisignatureTransaction).not.to.have.property(
+					'id',
+				);
 			});
 		});
 	});

--- a/test/transactions/5_create_dapp.js
+++ b/test/transactions/5_create_dapp.js
@@ -61,201 +61,207 @@ describe('#createDapp transaction', () => {
 		});
 
 		it('should create a create dapp transaction', () => {
-			return createDappTransaction.should.be.ok;
+			return expect(createDappTransaction).to.be.ok;
 		});
 
 		it('should throw an error if no options are provided', () => {
-			return createDapp.bind(null, { passphrase }).should.throw(noOptionsError);
+			return expect(createDapp.bind(null, { passphrase })).to.throw(
+				noOptionsError,
+			);
 		});
 
 		it('should throw an error if no category is provided', () => {
 			delete options.category;
-			return createDapp
-				.bind(null, { passphrase, options })
-				.should.throw(categoryIntegerError);
+			return expect(createDapp.bind(null, { passphrase, options })).to.throw(
+				categoryIntegerError,
+			);
 		});
 
 		it('should throw an error if provided category is not an integer', () => {
 			options.category = 'not an integer';
-			return createDapp
-				.bind(null, { passphrase, options })
-				.should.throw(categoryIntegerError);
+			return expect(createDapp.bind(null, { passphrase, options })).to.throw(
+				categoryIntegerError,
+			);
 		});
 
 		it('should throw an error if no name is provided', () => {
 			delete options.name;
-			return createDapp
-				.bind(null, { passphrase, options })
-				.should.throw(nameStringError);
+			return expect(createDapp.bind(null, { passphrase, options })).to.throw(
+				nameStringError,
+			);
 		});
 
 		it('should throw an error if provided name is not a string', () => {
 			options.name = 123;
-			return createDapp
-				.bind(null, { passphrase, options })
-				.should.throw(nameStringError);
+			return expect(createDapp.bind(null, { passphrase, options })).to.throw(
+				nameStringError,
+			);
 		});
 
 		it('should throw an error if no type is provided', () => {
 			delete options.type;
-			return createDapp
-				.bind(null, { passphrase, options })
-				.should.throw(typeIntegerError);
+			return expect(createDapp.bind(null, { passphrase, options })).to.throw(
+				typeIntegerError,
+			);
 		});
 
 		it('should throw an error if provided type is not an integer', () => {
 			options.type = 'not an integer';
-			return createDapp
-				.bind(null, { passphrase, options })
-				.should.throw(typeIntegerError);
+			return expect(createDapp.bind(null, { passphrase, options })).to.throw(
+				typeIntegerError,
+			);
 		});
 
 		it('should throw an error if no link is provided', () => {
 			delete options.link;
-			return createDapp
-				.bind(null, { passphrase, options })
-				.should.throw(linkStringError);
+			return expect(createDapp.bind(null, { passphrase, options })).to.throw(
+				linkStringError,
+			);
 		});
 
 		it('should throw an error if provided link is not a string', () => {
 			options.link = 123;
-			return createDapp
-				.bind(null, { passphrase, options })
-				.should.throw(linkStringError);
+			return expect(createDapp.bind(null, { passphrase, options })).to.throw(
+				linkStringError,
+			);
 		});
 
 		it('should not require description, tags, or icon', () => {
 			['description', 'tags', 'icon'].forEach(key => delete options[key]);
-			return createDapp.bind(null, { passphrase, options }).should.not.throw();
+			return expect(
+				createDapp.bind(null, { passphrase, options }),
+			).not.to.throw();
 		});
 
 		it('should use time.getTimeWithOffset to calculate the timestamp', () => {
-			return getTimeWithOffsetStub.should.be.calledWithExactly(undefined);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(undefined);
 		});
 
 		it('should use time.getTimeWithOffset with an offset of -10 seconds to calculate the timestamp', () => {
 			const offset = -10;
 			createDapp({ passphrase, options, timeOffset: offset });
 
-			return getTimeWithOffsetStub.should.be.calledWithExactly(offset);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(offset);
 		});
 
 		describe('returned create dapp transaction', () => {
 			it('should be an object', () => {
-				return createDappTransaction.should.be.an('object');
+				return expect(createDappTransaction).to.be.an('object');
 			});
 
 			it('should have an id string', () => {
-				return createDappTransaction.should.have
-					.property('id')
+				return expect(createDappTransaction)
+					.to.have.property('id')
 					.and.be.a('string');
 			});
 
 			it('should have type number equal to 5', () => {
-				return createDappTransaction.should.have
-					.property('type')
+				return expect(createDappTransaction)
+					.to.have.property('type')
 					.and.be.a('number')
 					.and.equal(5);
 			});
 
 			it('should have amount string equal to 0', () => {
-				return createDappTransaction.should.have
-					.property('amount')
+				return expect(createDappTransaction)
+					.to.have.property('amount')
 					.and.be.a('string')
 					.and.equal('0');
 			});
 
 			it('should have fee string equal to 25 LSK', () => {
-				return createDappTransaction.should.have
-					.property('fee')
+				return expect(createDappTransaction)
+					.to.have.property('fee')
 					.and.be.a('string')
 					.and.equal(fee);
 			});
 
 			it('should have recipientId equal to null', () => {
-				return createDappTransaction.should.have.property('recipientId').and.be
-					.null;
+				return expect(createDappTransaction).to.have.property('recipientId').and
+					.be.null;
 			});
 
 			it('should have senderPublicKey hex string equal to sender public key', () => {
-				return createDappTransaction.should.have
-					.property('senderPublicKey')
+				return expect(createDappTransaction)
+					.to.have.property('senderPublicKey')
 					.and.be.hexString.and.equal(publicKey);
 			});
 
 			it('should have timestamp number equal to result of time.getTimeWithOffset', () => {
-				return createDappTransaction.should.have
-					.property('timestamp')
+				return expect(createDappTransaction)
+					.to.have.property('timestamp')
 					.and.be.a('number')
 					.and.equal(timeWithOffset);
 			});
 
 			it('should have signature hex string', () => {
-				return createDappTransaction.should.have.property('signature').and.be
-					.hexString;
+				return expect(createDappTransaction).to.have.property('signature').and
+					.be.hexString;
 			});
 
 			it('should not have the second signature property', () => {
-				return createDappTransaction.should.not.have.property('signSignature');
+				return expect(createDappTransaction).not.to.have.property(
+					'signSignature',
+				);
 			});
 
 			it('should have asset', () => {
-				return createDappTransaction.should.have.property('asset').and.not.be
-					.empty;
+				return expect(createDappTransaction).to.have.property('asset').and.not
+					.be.empty;
 			});
 
 			describe('dapps asset', () => {
 				it('should be object', () => {
-					return createDappTransaction.asset.should.have
-						.property('dapp')
+					return expect(createDappTransaction.asset)
+						.to.have.property('dapp')
 						.and.be.an('object');
 				});
 
 				it('should have a category number equal to provided category', () => {
-					return createDappTransaction.asset.dapp.should.have
-						.property('category')
+					return expect(createDappTransaction.asset.dapp)
+						.to.have.property('category')
 						.and.be.a('number')
 						.and.equal(options.category);
 				});
 
 				it('should have a name string equal to provided name', () => {
-					return createDappTransaction.asset.dapp.should.have
-						.property('name')
+					return expect(createDappTransaction.asset.dapp)
+						.to.have.property('name')
 						.and.be.a('string')
 						.and.equal(options.name);
 				});
 
 				it('should have a description string equal to provided description', () => {
-					return createDappTransaction.asset.dapp.should.have
-						.property('description')
+					return expect(createDappTransaction.asset.dapp)
+						.to.have.property('description')
 						.and.be.a('string')
 						.and.equal(options.description);
 				});
 
 				it('should have a tags string equal to provided tags', () => {
-					return createDappTransaction.asset.dapp.should.have
-						.property('tags')
+					return expect(createDappTransaction.asset.dapp)
+						.to.have.property('tags')
 						.and.be.a('string')
 						.and.equal(options.tags);
 				});
 
 				it('should have a type number equal to provided type', () => {
-					return createDappTransaction.asset.dapp.should.have
-						.property('type')
+					return expect(createDappTransaction.asset.dapp)
+						.to.have.property('type')
 						.and.be.a('number')
 						.and.equal(options.type);
 				});
 
 				it('should have a link string equal to provided link', () => {
-					return createDappTransaction.asset.dapp.should.have
-						.property('link')
+					return expect(createDappTransaction.asset.dapp)
+						.to.have.property('link')
 						.and.be.a('string')
 						.and.equal(options.link);
 				});
 
 				it('should have an icon string equal to provided icon', () => {
-					return createDappTransaction.asset.dapp.should.have
-						.property('icon')
+					return expect(createDappTransaction.asset.dapp)
+						.to.have.property('icon')
 						.and.be.a('string')
 						.and.equal(options.icon);
 				});
@@ -274,8 +280,8 @@ describe('#createDapp transaction', () => {
 		});
 
 		it('should have the second signature property as hex string', () => {
-			return createDappTransaction.should.have.property('signSignature').and.be
-				.hexString;
+			return expect(createDappTransaction).to.have.property('signSignature').and
+				.be.hexString;
 		});
 	});
 
@@ -289,40 +295,42 @@ describe('#createDapp transaction', () => {
 			});
 
 			it('should have the type', () => {
-				return createDappTransaction.should.have
-					.property('type')
+				return expect(createDappTransaction)
+					.to.have.property('type')
 					.equal(transactionType);
 			});
 
 			it('should have the amount', () => {
-				return createDappTransaction.should.have
-					.property('amount')
+				return expect(createDappTransaction)
+					.to.have.property('amount')
 					.equal(amount);
 			});
 
 			it('should have the fee', () => {
-				return createDappTransaction.should.have.property('fee').equal(fee);
+				return expect(createDappTransaction)
+					.to.have.property('fee')
+					.equal(fee);
 			});
 
 			it('should have the recipient id', () => {
-				return createDappTransaction.should.have
-					.property('recipientId')
+				return expect(createDappTransaction)
+					.to.have.property('recipientId')
 					.equal(null);
 			});
 
 			it('should have the sender public key', () => {
-				return createDappTransaction.should.have
-					.property('senderPublicKey')
+				return expect(createDappTransaction)
+					.to.have.property('senderPublicKey')
 					.equal(null);
 			});
 
 			it('should have the timestamp', () => {
-				return createDappTransaction.should.have.property('timestamp');
+				return expect(createDappTransaction).to.have.property('timestamp');
 			});
 
 			it('should have the asset with dapp with properties category, description, name, tags, type, link, icon', () => {
-				return createDappTransaction.should.have.nested
-					.property('asset.dapp')
+				return expect(createDappTransaction)
+					.to.have.nested.property('asset.dapp')
 					.with.all.keys(
 						'category',
 						'description',
@@ -335,11 +343,11 @@ describe('#createDapp transaction', () => {
 			});
 
 			it('should not have the signature', () => {
-				return createDappTransaction.should.not.have.property('signature');
+				return expect(createDappTransaction).not.to.have.property('signature');
 			});
 
 			it('should not have the id', () => {
-				return createDappTransaction.should.not.have.property('id');
+				return expect(createDappTransaction).not.to.have.property('id');
 			});
 		});
 	});

--- a/test/transactions/6_transfer_into_dapp.js
+++ b/test/transactions/6_transfer_into_dapp.js
@@ -50,90 +50,91 @@ describe('#transferIntoDapp transaction', () => {
 		});
 
 		it('should create an inTransfer dapp transaction', () => {
-			return transferIntoDappTransaction.should.be.ok;
+			return expect(transferIntoDappTransaction).to.be.ok;
 		});
 
 		it('should use time.getTimeWithOffset to get the time for the timestamp', () => {
-			return getTimeWithOffsetStub.should.be.calledWithExactly(undefined);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(undefined);
 		});
 
 		it('should use time.getTimeWithOffset with an offset of -10 seconds to get the time for the timestamp', () => {
 			transferIntoDapp({ dappId, amount, passphrase, timeOffset: offset });
 
-			return getTimeWithOffsetStub.should.be.calledWithExactly(offset);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(offset);
 		});
 
 		describe('returned inTransfer transaction object', () => {
 			it('should be an object', () => {
-				return transferIntoDappTransaction.should.be.an('object');
+				return expect(transferIntoDappTransaction).to.be.an('object');
 			});
 
 			it('should have id string', () => {
-				return transferIntoDappTransaction.should.have
-					.property('id')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('id')
 					.and.be.a('string');
 			});
 
 			it('should have type number equal to 6', () => {
-				return transferIntoDappTransaction.should.have
-					.property('type')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('type')
 					.and.be.a('number')
 					.and.equal(transactionType);
 			});
 
 			it('should have amount string equal to 10 LSK', () => {
-				return transferIntoDappTransaction.should.have
-					.property('amount')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('amount')
 					.and.be.a('string')
 					.and.equal(amount);
 			});
 
 			it('should have fee string equal to 0.1 LSK', () => {
-				return transferIntoDappTransaction.should.have
-					.property('fee')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('fee')
 					.and.be.a('string')
 					.and.equal(transferFee);
 			});
 
 			it('should have recipientId equal to null', () => {
-				return transferIntoDappTransaction.should.have.property('recipientId')
-					.be.null;
+				return expect(transferIntoDappTransaction).to.have.property(
+					'recipientId',
+				).be.null;
 			});
 
 			it('should have senderPublicKey hex string equal to sender public key', () => {
-				return transferIntoDappTransaction.should.have
-					.property('senderPublicKey')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('senderPublicKey')
 					.and.be.hexString.and.equal(publicKey);
 			});
 
 			it('should have timestamp number equal to result of time.getTimeWithOffset', () => {
-				return transferIntoDappTransaction.should.have
-					.property('timestamp')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('timestamp')
 					.and.be.a('number')
 					.and.equal(timeWithOffset);
 			});
 
 			it('should have signature hex string', () => {
-				return transferIntoDappTransaction.should.have.property('signature').and
-					.be.hexString;
+				return expect(transferIntoDappTransaction).to.have.property('signature')
+					.and.be.hexString;
 			});
 
 			it('should not have the second signature property', () => {
-				return transferIntoDappTransaction.should.not.have.property(
+				return expect(transferIntoDappTransaction).not.to.have.property(
 					'signSignature',
 				);
 			});
 
 			it('should have an asset object', () => {
-				return transferIntoDappTransaction.should.have
-					.property('asset')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('asset')
 					.and.be.an('object');
 			});
 
 			describe('asset', () => {
 				it('should have the in transfer dapp id', () => {
-					return transferIntoDappTransaction.asset.should.have
-						.property('inTransfer')
+					return expect(transferIntoDappTransaction.asset)
+						.to.have.property('inTransfer')
 						.with.property('dappId')
 						.and.be.equal(dappId);
 				});
@@ -153,8 +154,9 @@ describe('#transferIntoDapp transaction', () => {
 		});
 
 		it('should have the second signature property as hex string', () => {
-			return transferIntoDappTransaction.should.have.property('signSignature')
-				.and.be.hexString;
+			return expect(transferIntoDappTransaction).to.have.property(
+				'signSignature',
+			).and.be.hexString;
 		});
 	});
 
@@ -169,54 +171,56 @@ describe('#transferIntoDapp transaction', () => {
 			});
 
 			it('should have the type', () => {
-				return transferIntoDappTransaction.should.have
-					.property('type')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('type')
 					.equal(transactionType);
 			});
 
 			it('should have the amount', () => {
-				return transferIntoDappTransaction.should.have
-					.property('amount')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('amount')
 					.equal(amount);
 			});
 
 			it('should have the fee', () => {
-				return transferIntoDappTransaction.should.have
-					.property('fee')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('fee')
 					.equal(transferFee);
 			});
 
 			it('should have the recipient id', () => {
-				return transferIntoDappTransaction.should.have
-					.property('recipientId')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('recipientId')
 					.equal(null);
 			});
 
 			it('should have the sender public key', () => {
-				return transferIntoDappTransaction.should.have
-					.property('senderPublicKey')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('senderPublicKey')
 					.equal(null);
 			});
 
 			it('should have the timestamp', () => {
-				return transferIntoDappTransaction.should.have.property('timestamp');
+				return expect(transferIntoDappTransaction).to.have.property(
+					'timestamp',
+				);
 			});
 
 			it('should have the asset with the in transfer with the dappId', () => {
-				return transferIntoDappTransaction.should.have
-					.property('asset')
+				return expect(transferIntoDappTransaction)
+					.to.have.property('asset')
 					.with.property('inTransfer')
 					.with.property('dappId');
 			});
 
 			it('should not have the signature', () => {
-				return transferIntoDappTransaction.should.not.have.property(
+				return expect(transferIntoDappTransaction).not.to.have.property(
 					'signature',
 				);
 			});
 
 			it('should not have the id', () => {
-				return transferIntoDappTransaction.should.not.have.property('id');
+				return expect(transferIntoDappTransaction).not.to.have.property('id');
 			});
 		});
 	});

--- a/test/transactions/7_transfer_out_of_dapp.js
+++ b/test/transactions/7_transfer_out_of_dapp.js
@@ -54,11 +54,11 @@ describe('#transferOutOfDapp', () => {
 		});
 
 		it('should create an out transfer dapp transaction', () => {
-			return transferOutOfDappTransaction.should.be.ok;
+			return expect(transferOutOfDappTransaction).to.be.ok;
 		});
 
 		it('should use time.getTimeWithOffset to get the time for the timestamp', () => {
-			return getTimeWithOffsetStub.should.be.calledWithExactly(undefined);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(undefined);
 		});
 
 		it('should use time.getTimeWithOffset with an offset of -10 seconds to get the time for the timestamp', () => {
@@ -71,88 +71,89 @@ describe('#transferOutOfDapp', () => {
 				timeOffset: offset,
 			});
 
-			return getTimeWithOffsetStub.should.be.calledWithExactly(offset);
+			return expect(getTimeWithOffsetStub).to.be.calledWithExactly(offset);
 		});
 
 		describe('returned out of dapp transfer transaction object', () => {
 			it('should be an object', () => {
-				return transferOutOfDappTransaction.should.be.an('object');
+				return expect(transferOutOfDappTransaction).to.be.an('object');
 			});
 
 			it('should have id string', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('id')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('id')
 					.and.be.a('string');
 			});
 
 			it('should have type number equal to 7', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('type')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('type')
 					.and.be.a('number')
 					.and.equal(transactionType);
 			});
 
 			it('should have amount string equal to 10 LSK', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('amount')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('amount')
 					.and.be.a('string')
 					.and.equal(amount);
 			});
 
 			it('should have fee string equal to 0.1 LSK', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('fee')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('fee')
 					.and.be.a('string')
 					.and.equal(fee);
 			});
 
 			it('should have recipientId equal to provided recipientId', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('recipientId')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('recipientId')
 					.and.be.equal(recipientId);
 			});
 
 			it('should have senderPublicKey hex string equal to sender public key', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('senderPublicKey')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('senderPublicKey')
 					.and.be.hexString.and.equal(publicKey);
 			});
 
 			it('should have timestamp number equal to result of time.getTimeWithOffset', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('timestamp')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('timestamp')
 					.and.be.a('number')
 					.and.equal(timeWithOffset);
 			});
 
 			it('should have signature hex string', () => {
-				return transferOutOfDappTransaction.should.have.property('signature')
-					.and.be.hexString;
+				return expect(transferOutOfDappTransaction).to.have.property(
+					'signature',
+				).and.be.hexString;
 			});
 
 			it('should not have the second signature property', () => {
-				return transferOutOfDappTransaction.should.not.have.property(
+				return expect(transferOutOfDappTransaction).not.to.have.property(
 					'signSignature',
 				);
 			});
 
 			it('should have an asset object', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('asset')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('asset')
 					.and.be.an('object');
 			});
 
 			describe('asset', () => {
 				it('should have the out transfer dapp id', () => {
-					return transferOutOfDappTransaction.asset.should.have
-						.property('outTransfer')
+					return expect(transferOutOfDappTransaction.asset)
+						.to.have.property('outTransfer')
 						.with.property('dappId')
 						.and.be.equal(dappId);
 				});
 
 				it('should have the out transfer transaction id', () => {
-					return transferOutOfDappTransaction.asset.should.have
-						.property('outTransfer')
+					return expect(transferOutOfDappTransaction.asset)
+						.to.have.property('outTransfer')
 						.with.property('transactionId')
 						.and.be.equal(transactionId);
 				});
@@ -173,7 +174,7 @@ describe('#transferOutOfDapp', () => {
 			});
 
 			it('should have the second signature property as hex string', () => {
-				return transferOutOfDappTransaction.should.have.property(
+				return expect(transferOutOfDappTransaction).to.have.property(
 					'signSignature',
 				).and.be.hexString;
 			});
@@ -193,53 +194,55 @@ describe('#transferOutOfDapp', () => {
 			});
 
 			it('should have the type', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('type')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('type')
 					.equal(transactionType);
 			});
 
 			it('should have the amount', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('amount')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('amount')
 					.equal(amount);
 			});
 
 			it('should have the fee', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('fee')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('fee')
 					.equal(fee);
 			});
 
 			it('should have the recipient id', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('recipientId')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('recipientId')
 					.equal(recipientId);
 			});
 
 			it('should have the sender public key', () => {
-				return transferOutOfDappTransaction.should.have
-					.property('senderPublicKey')
+				return expect(transferOutOfDappTransaction)
+					.to.have.property('senderPublicKey')
 					.equal(null);
 			});
 
 			it('should have the timestamp', () => {
-				return transferOutOfDappTransaction.should.have.property('timestamp');
+				return expect(transferOutOfDappTransaction).to.have.property(
+					'timestamp',
+				);
 			});
 
 			it('should have the asset with the out transfer with dappId and transactionId', () => {
-				return transferOutOfDappTransaction.should.have.nested
-					.property('asset.outTransfer')
+				return expect(transferOutOfDappTransaction)
+					.to.have.nested.property('asset.outTransfer')
 					.with.all.keys('dappId', 'transactionId');
 			});
 
 			it('should not have the signature', () => {
-				return transferOutOfDappTransaction.should.not.have.property(
+				return expect(transferOutOfDappTransaction).not.to.have.property(
 					'signature',
 				);
 			});
 
 			it('should not have the id', () => {
-				return transferOutOfDappTransaction.should.not.have.property('id');
+				return expect(transferOutOfDappTransaction).not.to.have.property('id');
 			});
 		});
 	});

--- a/test/transactions/constants.js
+++ b/test/transactions/constants.js
@@ -26,43 +26,43 @@ import {
 } from 'transactions/constants';
 
 describe('transactions constants module', () => {
-	it('FIXED_POINT should be an integer', () => {
-		return FIXED_POINT.should.be.an.integer;
+	it('FIXED_POINT to be an integer', () => {
+		return expect(FIXED_POINT).to.be.an.integer;
 	});
 
-	it('DAPP_FEE should be an integer', () => {
-		return DAPP_FEE.should.be.an.integer;
+	it('DAPP_FEE to be an integer', () => {
+		return expect(DAPP_FEE).to.be.an.integer;
 	});
 
-	it('DELEGATE_FEE should be an integer', () => {
-		return DELEGATE_FEE.should.be.an.integer;
+	it('DELEGATE_FEE to be an integer', () => {
+		return expect(DELEGATE_FEE).to.be.an.integer;
 	});
 
-	it('IN_TRANSFER_FEE should be an integer', () => {
-		return IN_TRANSFER_FEE.should.be.an.integer;
+	it('IN_TRANSFER_FEE to be an integer', () => {
+		return expect(IN_TRANSFER_FEE).to.be.an.integer;
 	});
 
-	it('OUT_TRANSFER_FEE should be an integer', () => {
-		return OUT_TRANSFER_FEE.should.be.an.integer;
+	it('OUT_TRANSFER_FEE to be an integer', () => {
+		return expect(OUT_TRANSFER_FEE).to.be.an.integer;
 	});
 
-	it('MULTISIGNATURE_FEE should be an integer', () => {
-		return MULTISIGNATURE_FEE.should.be.an.integer;
+	it('MULTISIGNATURE_FEE to be an integer', () => {
+		return expect(MULTISIGNATURE_FEE).to.be.an.integer;
 	});
 
-	it('SIGNATURE_FEE should be an integer', () => {
-		return SIGNATURE_FEE.should.be.an.integer;
+	it('SIGNATURE_FEE to be an integer', () => {
+		return expect(SIGNATURE_FEE).to.be.an.integer;
 	});
 
-	it('TRANSFER_FEE should be an integer', () => {
-		return TRANSFER_FEE.should.be.an.integer;
+	it('TRANSFER_FEE to be an integer', () => {
+		return expect(TRANSFER_FEE).to.be.an.integer;
 	});
 
-	it('VOTE_FEE should be an integer', () => {
-		return VOTE_FEE.should.be.an.integer;
+	it('VOTE_FEE to be an integer', () => {
+		return expect(VOTE_FEE).to.be.an.integer;
 	});
 
-	it('DATA_FEE should be an integer', () => {
-		return DATA_FEE.should.be.an.integer;
+	it('DATA_FEE to be an integer', () => {
+		return expect(DATA_FEE).to.be.an.integer;
 	});
 });

--- a/test/transactions/index.js
+++ b/test/transactions/index.js
@@ -14,49 +14,53 @@
  */
 import transaction from 'transactions';
 
-describe('transactions', () => {
+describe('expect(transaction)s', () => {
 	describe('exports', () => {
-		it('should have the create transfer transaction function', () => {
-			return transaction.should.have.property('transfer').and.be.a('function');
-		});
-
-		it('should have the register second passphrase transaction function', () => {
-			return transaction.should.have
-				.property('registerSecondPassphrase')
+		it('to have the create transfer expect(transaction) function', () => {
+			return expect(transaction)
+				.to.have.property('transfer')
 				.and.be.a('function');
 		});
 
-		it('should have the register delegate transaction function', () => {
-			return transaction.should.have
-				.property('registerDelegate')
+		it('to have the register second passphrase expect(transaction) function', () => {
+			return expect(transaction)
+				.to.have.property('registerSecondPassphrase')
 				.and.be.a('function');
 		});
 
-		it('should have the cast votes transaction function', () => {
-			return transaction.should.have.property('castVotes').and.be.a('function');
-		});
-
-		it('should have the register multisignature transaction function', () => {
-			return transaction.should.have
-				.property('registerMultisignature')
+		it('to have the register delegate expect(transaction) function', () => {
+			return expect(transaction)
+				.to.have.property('registerDelegate')
 				.and.be.a('function');
 		});
 
-		it('should have the create dapp transaction function', () => {
-			return transaction.should.have
-				.property('createDapp')
+		it('to have the cast votes expect(transaction) function', () => {
+			return expect(transaction)
+				.to.have.property('castVotes')
 				.and.be.a('function');
 		});
 
-		it('should have the transfer into dapp transaction function', () => {
-			return transaction.should.have
-				.property('transferIntoDapp')
+		it('to have the register multisignature expect(transaction) function', () => {
+			return expect(transaction)
+				.to.have.property('registerMultisignature')
 				.and.be.a('function');
 		});
 
-		it('should have the transfer out of dapp transaction function', () => {
-			return transaction.should.have
-				.property('transferOutOfDapp')
+		it('to have the create dapp expect(transaction) function', () => {
+			return expect(transaction)
+				.to.have.property('createDapp')
+				.and.be.a('function');
+		});
+
+		it('to have the transfer into dapp expect(transaction) function', () => {
+			return expect(transaction)
+				.to.have.property('transferIntoDapp')
+				.and.be.a('function');
+		});
+
+		it('to have the transfer out of dapp expect(transaction) function', () => {
+			return expect(transaction)
+				.to.have.property('transferOutOfDapp')
 				.and.be.a('function');
 		});
 	});

--- a/test/transactions/utils/format.js
+++ b/test/transactions/utils/format.js
@@ -31,7 +31,7 @@ describe('format', () => {
 					'+922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa',
 					'+5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09',
 				];
-				return prependPlusToPublicKeys(publicKeys).should.be.eql(
+				return expect(prependPlusToPublicKeys(publicKeys)).to.be.eql(
 					expectedOutput,
 				);
 			});
@@ -51,7 +51,7 @@ describe('format', () => {
 					'-922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa',
 					'-5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09',
 				];
-				return prependMinusToPublicKeys(publicKeys).should.be.eql(
+				return expect(prependMinusToPublicKeys(publicKeys)).to.be.eql(
 					expectedOutput,
 				);
 			});

--- a/test/transactions/utils/get_address_and_public_key_from_recipient_data.js
+++ b/test/transactions/utils/get_address_and_public_key_from_recipient_data.js
@@ -23,37 +23,43 @@ describe('#getAddressAndPublicKeyFromRecipientData', () => {
 
 	describe('When both recipientPublicKey and an address are given', () => {
 		it('when they match, it should return the address and publicKey', () => {
-			return getAddressAndPublicKeyFromRecipientData({
-				recipientId,
-				recipientPublicKey,
-			}).should.be.eql({ address: recipientId, publicKey: recipientPublicKey });
+			return expect(
+				getAddressAndPublicKeyFromRecipientData({
+					recipientId,
+					recipientPublicKey,
+				}),
+			).to.be.eql({ address: recipientId, publicKey: recipientPublicKey });
 		});
 
 		it('when they do not match, it should throw', () => {
-			return getAddressAndPublicKeyFromRecipientData
-				.bind(null, {
+			return expect(
+				getAddressAndPublicKeyFromRecipientData.bind(null, {
 					recipientId,
 					recipientPublicKey: recipientPublicKeyThatDoesNotMatchRecipientId,
-				})
-				.should.throw(
-					'Could not create transaction: recipientId does not match recipientPublicKey.',
-				);
+				}),
+			).to.throw(
+				'Could not create transaction: recipientId does not match recipientPublicKey.',
+			);
 		});
 	});
 
 	describe('When a recipientPublicKey and no address is given', () => {
 		it('it should return the address and the publicKey', () => {
-			return getAddressAndPublicKeyFromRecipientData({
-				recipientPublicKey,
-			}).should.be.eql({ address: recipientId, publicKey: recipientPublicKey });
+			return expect(
+				getAddressAndPublicKeyFromRecipientData({
+					recipientPublicKey,
+				}),
+			).to.be.eql({ address: recipientId, publicKey: recipientPublicKey });
 		});
 	});
 
 	describe('When an address is given but no publicKey', () => {
 		it('it should return the address and null for the publicKey', () => {
-			return getAddressAndPublicKeyFromRecipientData({
-				recipientId,
-			}).should.be.eql({
+			return expect(
+				getAddressAndPublicKeyFromRecipientData({
+					recipientId,
+				}),
+			).to.be.eql({
 				address: recipientId,
 				publicKey: null,
 			});

--- a/test/transactions/utils/get_transaction_bytes.js
+++ b/test/transactions/utils/get_transaction_bytes.js
@@ -73,7 +73,7 @@ describe('getTransactionBytes module', () => {
 				);
 				const transactionBytes = getTransactionBytes(defaultTransaction);
 
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 
 			it('should return Buffer of type 0 (transfer LSK) with data', () => {
@@ -84,7 +84,7 @@ describe('getTransactionBytes module', () => {
 				);
 				const transactionBytes = getTransactionBytes(defaultTransaction);
 
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 
 			it('should throw on type 0 with too much data', () => {
@@ -92,25 +92,25 @@ describe('getTransactionBytes module', () => {
 				defaultTransaction.asset.data = new Array(maxDataLength + 1)
 					.fill('1')
 					.join('');
-				return getTransactionBytes
-					.bind(null, defaultTransaction)
-					.should.throw('Transaction asset data exceeds size of 64.');
+				return expect(
+					getTransactionBytes.bind(null, defaultTransaction),
+				).to.throw('Transaction asset data exceeds size of 64.');
 			});
 
 			it('should throw on type 0 with an amount that is too small', () => {
 				const amount = -1;
 				defaultTransaction.amount = amount;
-				return getTransactionBytes
-					.bind(null, defaultTransaction)
-					.should.throw('Transaction amount must not be negative.');
+				return expect(
+					getTransactionBytes.bind(null, defaultTransaction),
+				).to.throw('Transaction amount must not be negative.');
 			});
 
 			it('should not throw on type 0 with an amount that is 0', () => {
 				const amount = 0;
 				defaultTransaction.amount = amount;
-				return getTransactionBytes
-					.bind(null, defaultTransaction)
-					.should.not.throw();
+				return expect(
+					getTransactionBytes.bind(null, defaultTransaction),
+				).not.to.throw();
 			});
 
 			it('should throw on type 0 with an amount that is too large', () => {
@@ -118,17 +118,17 @@ describe('getTransactionBytes module', () => {
 					.fromBuffer(Buffer.from(new Array(8).fill(255)))
 					.plus(1);
 				defaultTransaction.amount = amount;
-				return getTransactionBytes
-					.bind(null, defaultTransaction)
-					.should.throw('Transaction amount is too large.');
+				return expect(
+					getTransactionBytes.bind(null, defaultTransaction),
+				).to.throw('Transaction amount is too large.');
 			});
 
 			it('should not throw on type 0 with an amount that is the maximum possible', () => {
 				const amount = bignum.fromBuffer(Buffer.from(new Array(8).fill(255)));
 				defaultTransaction.amount = amount;
-				return getTransactionBytes
-					.bind(null, defaultTransaction)
-					.should.not.throw();
+				return expect(
+					getTransactionBytes.bind(null, defaultTransaction),
+				).not.to.throw();
 			});
 
 			it('should return Buffer of transaction with second signature', () => {
@@ -138,7 +138,7 @@ describe('getTransactionBytes module', () => {
 					'hex',
 				);
 				const transactionBytes = getTransactionBytes(defaultTransaction);
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 
 			it('should return Buffer from multisignature type 0 (transfer LSK) transaction', () => {
@@ -162,7 +162,7 @@ describe('getTransactionBytes module', () => {
 				);
 				const transactionBytes = getTransactionBytes(multiSignatureTransaction);
 
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 
 			it('should return Buffer of type 0 (transfer LSK) with additional properties', () => {
@@ -173,7 +173,7 @@ describe('getTransactionBytes module', () => {
 				);
 				const transactionBytes = getTransactionBytes(defaultTransaction);
 
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 
 			it('should throw on missing required parameters', () => {
@@ -187,9 +187,9 @@ describe('getTransactionBytes module', () => {
 				return requiredProperties.forEach(parameter => {
 					const defaultTransactionClone = Object.assign({}, defaultTransaction);
 					delete defaultTransactionClone[parameter];
-					getTransactionBytes
-						.bind(null, defaultTransactionClone)
-						.should.throw(`${parameter} is a required parameter.`);
+					expect(
+						getTransactionBytes.bind(null, defaultTransactionClone),
+					).to.throw(`${parameter} is a required parameter.`);
 				});
 			});
 
@@ -204,9 +204,9 @@ describe('getTransactionBytes module', () => {
 				return requiredProperties.forEach(parameter => {
 					const defaultTransactionClone = Object.assign({}, defaultTransaction);
 					defaultTransactionClone[parameter] = undefined;
-					getTransactionBytes
-						.bind(null, defaultTransactionClone)
-						.should.throw(`${parameter} is a required parameter.`);
+					expect(
+						getTransactionBytes.bind(null, defaultTransactionClone),
+					).to.throw(`${parameter} is a required parameter.`);
 				});
 			});
 		});
@@ -231,7 +231,7 @@ describe('getTransactionBytes module', () => {
 				);
 				const transactionBytes = getTransactionBytes(signatureTransaction);
 
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 		});
 
@@ -257,7 +257,7 @@ describe('getTransactionBytes module', () => {
 					delegateRegistrationTransaction,
 				);
 
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 		});
 
@@ -286,7 +286,7 @@ describe('getTransactionBytes module', () => {
 				);
 				const transactionBytes = getTransactionBytes(voteTransaction);
 
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 		});
 
@@ -321,7 +321,7 @@ describe('getTransactionBytes module', () => {
 					createMultiSignatureTransaction,
 				);
 
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 		});
 
@@ -356,7 +356,7 @@ describe('getTransactionBytes module', () => {
 				);
 				const transactionBytes = getTransactionBytes(dappTransaction);
 
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 		});
 
@@ -380,7 +380,7 @@ describe('getTransactionBytes module', () => {
 				);
 				const transactionBytes = getTransactionBytes(inTransferTransction);
 
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 		});
 
@@ -409,7 +409,7 @@ describe('getTransactionBytes module', () => {
 				);
 				const transactionBytes = getTransactionBytes(outTransferTransaction);
 
-				return transactionBytes.should.be.eql(expectedBuffer);
+				return expect(transactionBytes).to.be.eql(expectedBuffer);
 			});
 		});
 	});
@@ -425,7 +425,7 @@ describe('getTransactionBytes module', () => {
 					1: 10,
 				};
 
-				return checkRequiredFields(arrayToCheck, objectParameter).should.be
+				return expect(checkRequiredFields(arrayToCheck, objectParameter)).to.be
 					.true;
 			});
 
@@ -436,9 +436,9 @@ describe('getTransactionBytes module', () => {
 					1: 10,
 				};
 
-				return checkRequiredFields
-					.bind(null, arrayToCheck, objectParameter)
-					.should.throw('ThirdValue is a required parameter.');
+				return expect(
+					checkRequiredFields.bind(null, arrayToCheck, objectParameter),
+				).to.throw('ThirdValue is a required parameter.');
 			});
 		});
 
@@ -450,12 +450,12 @@ describe('getTransactionBytes module', () => {
 					data: 'my data input',
 				});
 
-				return assetDataBuffer.should.be.eql(expectedBuffer);
+				return expect(assetDataBuffer).to.be.eql(expectedBuffer);
 			});
 
 			it('should return empty Buffer for no asset data', () => {
 				const assetDataBuffer = getAssetDataForTransferTransaction({});
-				return assetDataBuffer.should.be.eql(defaultEmptyBuffer);
+				return expect(assetDataBuffer).to.be.eql(defaultEmptyBuffer);
 			});
 		});
 
@@ -470,13 +470,15 @@ describe('getTransactionBytes module', () => {
 					},
 				);
 
-				return assetSignaturesPublicKeyBuffer.should.be.eql(expectedBuffer);
+				return expect(assetSignaturesPublicKeyBuffer).to.be.eql(expectedBuffer);
 			});
 
 			it('should throw on missing publicKey in the signature asset', () => {
-				return getAssetDataForRegisterSecondSignatureTransaction
-					.bind(null, { signature: {} })
-					.should.throw('publicKey is a required parameter.');
+				return expect(
+					getAssetDataForRegisterSecondSignatureTransaction.bind(null, {
+						signature: {},
+					}),
+				).to.throw('publicKey is a required parameter.');
 			});
 		});
 
@@ -491,13 +493,15 @@ describe('getTransactionBytes module', () => {
 					},
 				);
 
-				return assetDelegateUsernameBuffer.should.be.eql(expectedBuffer);
+				return expect(assetDelegateUsernameBuffer).to.be.eql(expectedBuffer);
 			});
 
 			it('should throw on missing username in the delegate asset', () => {
-				return getAssetDataForRegisterDelegateTransaction
-					.bind(null, { delegate: {} })
-					.should.throw('username is a required parameter.');
+				return expect(
+					getAssetDataForRegisterDelegateTransaction.bind(null, {
+						delegate: {},
+					}),
+				).to.throw('username is a required parameter.');
 			});
 		});
 
@@ -515,13 +519,13 @@ describe('getTransactionBytes module', () => {
 				);
 				const assetVoteBuffer = getAssetDataForCastVotesTransaction(votesAsset);
 
-				return assetVoteBuffer.should.be.eql(expectedBuffer);
+				return expect(assetVoteBuffer).to.be.eql(expectedBuffer);
 			});
 
 			it('should throw on missing votes in the vote asset', () => {
-				return getAssetDataForCastVotesTransaction
-					.bind(null, { votes: {} })
-					.should.throw('votes parameter must be an Array.');
+				return expect(
+					getAssetDataForCastVotesTransaction.bind(null, { votes: {} }),
+				).to.throw('votes parameter must be an Array.');
 			});
 		});
 
@@ -556,7 +560,7 @@ describe('getTransactionBytes module', () => {
 					multisignatureAsset,
 				);
 
-				return multisignatureBuffer.should.be.eql(expectedBuffer);
+				return expect(multisignatureBuffer).to.be.eql(expectedBuffer);
 			});
 
 			it('should throw on missing required parameters', () => {
@@ -568,9 +572,11 @@ describe('getTransactionBytes module', () => {
 						multisignatureAsset.multisignature,
 					);
 					delete multisigAsset[parameter];
-					getAssetDataForRegisterMultisignatureAccountTransaction
-						.bind(null, { multisignature: multisigAsset })
-						.should.throw(`${parameter} is a required parameter.`);
+					expect(
+						getAssetDataForRegisterMultisignatureAccountTransaction.bind(null, {
+							multisignature: multisigAsset,
+						}),
+					).to.throw(`${parameter} is a required parameter.`);
 				});
 			});
 		});
@@ -629,7 +635,7 @@ describe('getTransactionBytes module', () => {
 				]);
 				const dappBuffer = getAssetDataForCreateDappTransaction(dappAsset);
 
-				return dappBuffer.should.be.eql(expectedBuffer);
+				return expect(dappBuffer).to.be.eql(expectedBuffer);
 			});
 
 			it('should throw for create dapp asset without required fields', () => {
@@ -647,9 +653,11 @@ describe('getTransactionBytes module', () => {
 				return requiredProperties.forEach(parameter => {
 					const dappClone = Object.assign({}, dapp);
 					delete dappClone[parameter];
-					getAssetDataForCreateDappTransaction
-						.bind(null, { dapp: dappClone })
-						.should.throw(`${parameter} is a required parameter.`);
+					expect(
+						getAssetDataForCreateDappTransaction.bind(null, {
+							dapp: dappClone,
+						}),
+					).to.throw(`${parameter} is a required parameter.`);
 				});
 			});
 		});
@@ -666,13 +674,15 @@ describe('getTransactionBytes module', () => {
 					dappInAsset,
 				);
 
-				return dappInTransferBuffer.should.be.eql(expectedBuffer);
+				return expect(dappInTransferBuffer).to.be.eql(expectedBuffer);
 			});
 
 			it('should throw on missing votes in the vote asset', () => {
-				return getAssetDataForTransferIntoDappTransaction
-					.bind(null, { inTransfer: {} })
-					.should.throw('dappId is a required parameter.');
+				return expect(
+					getAssetDataForTransferIntoDappTransaction.bind(null, {
+						inTransfer: {},
+					}),
+				).to.throw('dappId is a required parameter.');
 			});
 		});
 
@@ -694,13 +704,15 @@ describe('getTransactionBytes module', () => {
 					dappOutAsset,
 				);
 
-				return dappOutTransferBuffer.should.be.eql(expectedBuffer);
+				return expect(dappOutTransferBuffer).to.be.eql(expectedBuffer);
 			});
 
 			it('should throw on missing votes in the vote asset', () => {
-				return getAssetDataForTransferOutOfDappTransaction
-					.bind(null, { outTransfer: {} })
-					.should.throw('dappId is a required parameter.');
+				return expect(
+					getAssetDataForTransferOutOfDappTransaction.bind(null, {
+						outTransfer: {},
+					}),
+				).to.throw('dappId is a required parameter.');
 			});
 		});
 
@@ -727,16 +739,16 @@ describe('getTransactionBytes module', () => {
 				defaultTransaction.asset.data = new Array(maxDataLength + 1)
 					.fill('1')
 					.join('');
-				return checkTransaction
-					.bind(null, defaultTransaction)
-					.should.throw('Transaction asset data exceeds size of 64.');
+				return expect(checkTransaction.bind(null, defaultTransaction)).to.throw(
+					'Transaction asset data exceeds size of 64.',
+				);
 			});
 
 			it('should return true on asset data exactly at max data length', () => {
 				defaultTransaction.asset.data = new Array(maxDataLength)
 					.fill('1')
 					.join('');
-				return checkTransaction(defaultTransaction).should.be.true;
+				return expect(checkTransaction(defaultTransaction)).to.be.true;
 			});
 		});
 
@@ -745,14 +757,14 @@ describe('getTransactionBytes module', () => {
 				const allInvalidValues = [NaN, false, undefined];
 				return allInvalidValues.forEach(value => {
 					const invalid = isValidValue(value);
-					invalid.should.be.false;
+					expect(invalid).to.be.false;
 				});
 			});
 			it('should return true on valid values', () => {
 				const exampleValidValues = ['123', 123, { 1: 2, 3: 4 }, [1, 2, 3]];
 				return exampleValidValues.forEach(value => {
 					const valid = isValidValue(value);
-					valid.should.be.true;
+					expect(valid).to.be.true;
 				});
 			});
 		});

--- a/test/transactions/utils/get_transaction_hash.js
+++ b/test/transactions/utils/get_transaction_hash.js
@@ -47,7 +47,7 @@ describe('#getTransactionHash', () => {
 	});
 
 	it('should get transaction bytes', () => {
-		return transactionBytesStub.should.be.calledWithExactly(transaction);
+		return expect(transactionBytesStub).to.be.calledWithExactly(transaction);
 	});
 
 	it('should return a hash for a transaction object as a Buffer', () => {
@@ -55,6 +55,6 @@ describe('#getTransactionHash', () => {
 			'f60a26da470b1dc233fd526ed7306c1d84836f9e2ecee82c9ec47319e0910474',
 			'hex',
 		);
-		return result.should.be.eql(expected);
+		return expect(result).to.be.eql(expected);
 	});
 });

--- a/test/transactions/utils/get_transaction_id.js
+++ b/test/transactions/utils/get_transaction_id.js
@@ -48,6 +48,6 @@ describe('#getTransactionId', () => {
 		};
 		const id = getTransactionId(transaction);
 
-		return id.should.be.equal(defaultTransactionId);
+		return expect(id).to.be.equal(defaultTransactionId);
 	});
 });

--- a/test/transactions/utils/index.js
+++ b/test/transactions/utils/index.js
@@ -37,79 +37,81 @@ import {
 describe('transaction utils', () => {
 	describe('exports', () => {
 		it('should have checkPublicKeysForDuplicates', () => {
-			return checkPublicKeysForDuplicates.should.be.a('function');
+			return expect(checkPublicKeysForDuplicates).to.be.a('function');
 		});
 
 		it('should have getAddressAndPublicKeyFromRecipientData', () => {
-			return getAddressAndPublicKeyFromRecipientData.should.be.a('function');
+			return expect(getAddressAndPublicKeyFromRecipientData).to.be.a(
+				'function',
+			);
 		});
 
 		it('should have getTimeFromBlockchainEpoch', () => {
-			return getTimeFromBlockchainEpoch.should.be.a('function');
+			return expect(getTimeFromBlockchainEpoch).to.be.a('function');
 		});
 
 		it('should have getTimeWithOffset', () => {
-			return getTimeWithOffset.should.be.a('function');
+			return expect(getTimeWithOffset).to.be.a('function');
 		});
 
 		it('should have getTransactionBytes', () => {
-			return getTransactionBytes.should.be.a('function');
+			return expect(getTransactionBytes).to.be.a('function');
 		});
 
 		it('should have getTransactionHash', () => {
-			return getTransactionHash.should.be.a('function');
+			return expect(getTransactionHash).to.be.a('function');
 		});
 
 		it('should have getTransactionId', () => {
-			return getTransactionId.should.be.a('function');
+			return expect(getTransactionId).to.be.a('function');
 		});
 
 		it('should have prepareTransaction', () => {
-			return prepareTransaction.should.be.a('function');
+			return expect(prepareTransaction).to.be.a('function');
 		});
 
 		it('should have prependMinusToPublicKeys', () => {
-			return prependMinusToPublicKeys.should.be.a('function');
+			return expect(prependMinusToPublicKeys).to.be.a('function');
 		});
 
 		it('should have prependPlusToPublicKeys', () => {
-			return prependPlusToPublicKeys.should.be.a('function');
+			return expect(prependPlusToPublicKeys).to.be.a('function');
 		});
 
 		it('should have signRawTransaction', () => {
-			return signRawTransaction.should.be.a('function');
+			return expect(signRawTransaction).to.be.a('function');
 		});
 
 		it('should have signTransaction', () => {
-			return signTransaction.should.be.a('function');
+			return expect(signTransaction).to.be.a('function');
 		});
 
 		it('should have multiSignTransaction', () => {
-			return multiSignTransaction.should.be.a('function');
+			return expect(multiSignTransaction).to.be.a('function');
 		});
 
 		it('should have verifyTransaction', () => {
-			return verifyTransaction.should.be.a('function');
+			return expect(verifyTransaction).to.be.a('function');
 		});
 
 		it('should have validateAddress', () => {
-			return validateAddress.should.be.a('function');
+			return expect(validateAddress).to.be.a('function');
 		});
 
 		it('should have validateKeysgroup', () => {
-			return validateKeysgroup.should.be.a('function');
+			return expect(validateKeysgroup).to.be.a('function');
 		});
 
 		it('should have validatePublicKey', () => {
-			return validatePublicKey.should.be.a('function');
+			return expect(validatePublicKey).to.be.a('function');
 		});
 
 		it('should have validatePublicKeys', () => {
-			return validatePublicKeys.should.be.a('function');
+			return expect(validatePublicKeys).to.be.a('function');
 		});
 
 		it('should have wrapTransactionCreator', () => {
-			return wrapTransactionCreator.should.be.a('function');
+			return expect(wrapTransactionCreator).to.be.a('function');
 		});
 	});
 });

--- a/test/transactions/utils/prepare_transaction.js
+++ b/test/transactions/utils/prepare_transaction.js
@@ -50,18 +50,18 @@ describe('#prepareTransaction', () => {
 		});
 
 		it('should not mutate the original transaction', () => {
-			return inputTransaction.should.eql(defaultTransaction);
+			return expect(inputTransaction).to.eql(defaultTransaction);
 		});
 
 		it('should add a signature to a transaction', () => {
-			return preparedTransaction.should.have
-				.property('signature')
+			return expect(preparedTransaction)
+				.to.have.property('signature')
 				.and.be.hexString.and.equal(signature);
 		});
 
 		it('should add an id to a transaction', () => {
-			return preparedTransaction.should.have
-				.property('id')
+			return expect(preparedTransaction)
+				.to.have.property('id')
 				.and.match(/^[0-9]+$/)
 				.and.equal(id);
 		});
@@ -78,12 +78,12 @@ describe('#prepareTransaction', () => {
 		});
 
 		it('should not mutate the original transaction', () => {
-			return inputTransaction.should.eql(defaultTransaction);
+			return expect(inputTransaction).to.eql(defaultTransaction);
 		});
 
 		it('should add a second signature to a transaction if a second passphrase is provided', () => {
-			return preparedTransaction.should.have
-				.property('signSignature')
+			return expect(preparedTransaction)
+				.to.have.property('signSignature')
 				.and.be.hexString.and.equal(secondSignature);
 		});
 
@@ -101,7 +101,7 @@ describe('#prepareTransaction', () => {
 				passphrase,
 				secondPassphrase,
 			);
-			return preparedTransaction.should.not.have.property('signSignature');
+			return expect(preparedTransaction).not.to.have.property('signSignature');
 		});
 	});
 });

--- a/test/transactions/utils/sign_and_verify.js
+++ b/test/transactions/utils/sign_and_verify.js
@@ -80,18 +80,20 @@ describe('signAndVerify module', () => {
 			});
 
 			it('should get the transaction hash', () => {
-				return getTransactionHashStub.should.be.calledWithExactly(transaction);
+				return expect(getTransactionHashStub).to.be.calledWithExactly(
+					transaction,
+				);
 			});
 
 			it('should sign the transaction hash with the passphrase', () => {
-				return cryptoSignDataStub.should.be.calledWithExactly(
+				return expect(cryptoSignDataStub).to.be.calledWithExactly(
 					defaultHash,
 					defaultPassphrase,
 				);
 			});
 
 			it('should return the signature', () => {
-				return signature.should.be.equal(defaultSignature);
+				return expect(signature).to.be.equal(defaultSignature);
 			});
 		});
 
@@ -128,21 +130,23 @@ describe('signAndVerify module', () => {
 			});
 
 			it('should remove the signature and second signature before getting transaction hash', () => {
-				getTransactionHashStub.args[0].should.not.have.property('signature');
-				return getTransactionHashStub.args[0].should.not.have.property(
+				expect(getTransactionHashStub.args[0]).not.to.have.property(
+					'signature',
+				);
+				return expect(getTransactionHashStub.args[0]).not.to.have.property(
 					'signSignature',
 				);
 			});
 
 			it('should sign the transaction hash with the passphrase', () => {
-				return cryptoSignDataStub.should.be.calledWithExactly(
+				return expect(cryptoSignDataStub).to.be.calledWithExactly(
 					defaultMultisignatureHash,
 					defaultPassphrase,
 				);
 			});
 
 			it('should return the signature', () => {
-				return signature.should.be.equal(defaultSignature);
+				return expect(signature).to.be.equal(defaultSignature);
 			});
 		});
 
@@ -159,14 +163,14 @@ describe('signAndVerify module', () => {
 
 				it('should remove the signature before getting transaction hash', () => {
 					verifyTransaction(transaction);
-					return getTransactionHashStub.args[0].should.not.have.property(
+					return expect(getTransactionHashStub.args[0]).not.to.have.property(
 						'signature',
 					);
 				});
 
 				it('should verify the transaction using the hash, the signature and the public key', () => {
 					verifyTransaction(transaction);
-					return cryptoVerifyDataStub.should.be.calledWithExactly(
+					return expect(cryptoVerifyDataStub).to.be.calledWithExactly(
 						defaultHash,
 						defaultSignature,
 						defaultPublicKey,
@@ -176,12 +180,12 @@ describe('signAndVerify module', () => {
 				it('should return false for an invalid signature', () => {
 					cryptoVerifyDataStub.returns(false);
 					const verification = verifyTransaction(transaction);
-					return verification.should.be.false;
+					return expect(verification).to.be.false;
 				});
 
 				it('should return true for a valid signature', () => {
 					const verification = verifyTransaction(transaction);
-					return verification.should.be.true;
+					return expect(verification).to.be.true;
 				});
 			});
 
@@ -202,25 +206,23 @@ describe('signAndVerify module', () => {
 				});
 
 				it('should throw if attempting to verify without a secondPublicKey', () => {
-					return verifyTransaction
-						.bind(null, transaction)
-						.should.throw(
-							'Cannot verify signSignature without secondPublicKey.',
-						);
+					return expect(verifyTransaction.bind(null, transaction)).to.throw(
+						'Cannot verify signSignature without secondPublicKey.',
+					);
 				});
 
 				it('should remove the second signature before getting the first transaction hash', () => {
 					verifyTransaction(transaction, defaultSecondPublicKey);
-					return getTransactionHashStub.firstCall.args[0].should.not.have.property(
-						'signSignature',
-					);
+					return expect(
+						getTransactionHashStub.firstCall.args[0],
+					).not.to.have.property('signSignature');
 				});
 
 				it('should remove the first signature before getting the second transaction hash', () => {
 					verifyTransaction(transaction, defaultSecondPublicKey);
-					return getTransactionHashStub.secondCall.args[0].should.not.have.property(
-						'signature',
-					);
+					return expect(
+						getTransactionHashStub.secondCall.args[0],
+					).not.to.have.property('signature');
 				});
 
 				it('should return false for an invalid second signature', () => {
@@ -229,7 +231,7 @@ describe('signAndVerify module', () => {
 						transaction,
 						defaultSecondPublicKey,
 					);
-					return verification.should.be.false;
+					return expect(verification).to.be.false;
 				});
 
 				it('should return false for an invalid first signature', () => {
@@ -246,7 +248,7 @@ describe('signAndVerify module', () => {
 						transaction,
 						defaultSecondPublicKey,
 					);
-					return verification.should.be.false;
+					return expect(verification).to.be.false;
 				});
 
 				it('should return true for a valid signature', () => {
@@ -254,7 +256,7 @@ describe('signAndVerify module', () => {
 						transaction,
 						defaultSecondPublicKey,
 					);
-					return verification.should.be.true;
+					return expect(verification).to.be.true;
 				});
 			});
 		});
@@ -276,7 +278,7 @@ describe('signAndVerify module', () => {
 								const rawTx = Object.assign({}, transaction);
 								delete rawTx.signature;
 								delete rawTx.signSignature;
-								return signTransaction(rawTx, passphrase).should.be.equal(
+								return expect(signTransaction(rawTx, passphrase)).to.be.equal(
 									signature,
 								);
 							});
@@ -290,10 +292,9 @@ describe('signAndVerify module', () => {
 								if (signSignature) {
 									const rawTx = Object.assign({}, transaction);
 									delete rawTx.signSignature;
-									return signTransaction(
-										rawTx,
-										secondPassphrase,
-									).should.be.equal(signSignature);
+									return expect(
+										signTransaction(rawTx, secondPassphrase),
+									).to.be.equal(signSignature);
 								}
 								return true;
 							});
@@ -308,8 +309,8 @@ describe('signAndVerify module', () => {
 						'f9666bfed9ef2ff52a04408f22f2bfffaa81384c9433463697330224f10032a4';
 					it('should verify all the transactions', () => {
 						return validTransactions.forEach(transaction => {
-							return verifyTransaction(transaction, secondPublicKey).should.be
-								.true;
+							return expect(verifyTransaction(transaction, secondPublicKey)).to
+								.be.true;
 						});
 					});
 				});

--- a/test/transactions/utils/sign_raw_transaction.js
+++ b/test/transactions/utils/sign_raw_transaction.js
@@ -73,65 +73,75 @@ describe('#signRawTransaction', () => {
 				});
 
 				it('should have the type', () => {
-					return signedTransaction.should.have.property('type').equal(type);
+					return expect(signedTransaction)
+						.to.have.property('type')
+						.equal(type);
 				});
 
 				it('should have the amount', () => {
-					return signedTransaction.should.have.property('amount').equal(amount);
+					return expect(signedTransaction)
+						.to.have.property('amount')
+						.equal(amount);
 				});
 
 				it('should have the asset', () => {
-					return signedTransaction.should.have.property('asset').eql(asset);
+					return expect(signedTransaction)
+						.to.have.property('asset')
+						.eql(asset);
 				});
 
 				it('should have the senderPublicKey', () => {
-					return signedTransaction.should.have
-						.property('senderPublicKey')
+					return expect(signedTransaction)
+						.to.have.property('senderPublicKey')
 						.equal(senderPublicKey);
 				});
 
 				it('should have the senderId', () => {
-					return signedTransaction.should.have
-						.property('senderId')
+					return expect(signedTransaction)
+						.to.have.property('senderId')
 						.equal(senderId);
 				});
 
 				it('should have the recipientId', () => {
-					return signedTransaction.should.have
-						.property('recipientId')
+					return expect(signedTransaction)
+						.to.have.property('recipientId')
 						.equal(recipientId);
 				});
 
 				it('should have the fee', () => {
-					return signedTransaction.should.have.property('fee').equal(fee);
+					return expect(signedTransaction)
+						.to.have.property('fee')
+						.equal(fee);
 				});
 
 				it('should have the updated timestamp', () => {
-					return signedTransaction.should.have
-						.property('timestamp')
+					return expect(signedTransaction)
+						.to.have.property('timestamp')
 						.be.equal(timeWithOffset);
 				});
 
 				it('should have the senderSecondPublicKey', () => {
-					return signedTransaction.should.have
-						.property('senderSecondPublicKey')
+					return expect(signedTransaction)
+						.to.have.property('senderSecondPublicKey')
 						.equal(null);
 				});
 
 				it('should have the signature', () => {
-					return signedTransaction.should.have
-						.property('signature')
+					return expect(signedTransaction)
+						.to.have.property('signature')
 						.be.equal(signature);
 				});
 
 				it('should have the id', () => {
-					return signedTransaction.should.have
-						.property('id')
+					return expect(signedTransaction)
+						.to.have.property('id')
 						.be.equal(transactionId);
 				});
 
 				it('should use time.getTimeWithOffset to calculate the timestamp', () => {
-					return getTimeWithOffsetStub.should.be.calledWithExactly(undefined);
+					return expect(getTimeWithOffsetStub).to.be.calledWithExactly(
+						undefined,
+					);
 				});
 			});
 
@@ -158,73 +168,81 @@ describe('#signRawTransaction', () => {
 					});
 
 					it('should have the type', () => {
-						return signedTransaction.should.have.property('type').equal(type);
+						return expect(signedTransaction)
+							.to.have.property('type')
+							.equal(type);
 					});
 
 					it('should have the amount', () => {
-						return signedTransaction.should.have
-							.property('amount')
+						return expect(signedTransaction)
+							.to.have.property('amount')
 							.equal(amount);
 					});
 
 					it('should have the asset', () => {
-						return signedTransaction.should.have.property('asset').eql(asset);
+						return expect(signedTransaction)
+							.to.have.property('asset')
+							.eql(asset);
 					});
 
 					it('should have the senderPublicKey', () => {
-						return signedTransaction.should.have
-							.property('senderPublicKey')
+						return expect(signedTransaction)
+							.to.have.property('senderPublicKey')
 							.equal(senderPublicKey);
 					});
 
 					it('should have the senderId', () => {
-						return signedTransaction.should.have
-							.property('senderId')
+						return expect(signedTransaction)
+							.to.have.property('senderId')
 							.equal(senderId);
 					});
 
 					it('should have the recipientId', () => {
-						return signedTransaction.should.have
-							.property('recipientId')
+						return expect(signedTransaction)
+							.to.have.property('recipientId')
 							.equal(recipientId);
 					});
 
 					it('should have the fee', () => {
-						return signedTransaction.should.have.property('fee').equal(fee);
+						return expect(signedTransaction)
+							.to.have.property('fee')
+							.equal(fee);
 					});
 
 					it('should have the updated timestamp', () => {
-						return signedTransaction.should.have
-							.property('timestamp')
+						return expect(signedTransaction)
+							.to.have.property('timestamp')
 							.be.equal(timeWithOffset);
 					});
 
 					it('should have the senderSecondPublicKey', () => {
-						return signedTransaction.should.have
-							.property('senderSecondPublicKey')
+						return expect(signedTransaction)
+							.to.have.property('senderSecondPublicKey')
 							.equal(senderSecondPublicKey);
 					});
 
 					it('should have the signature', () => {
-						return signedTransaction.should.have
-							.property('signature')
+						return expect(signedTransaction)
+							.to.have.property('signature')
 							.be.eql(signature);
 					});
 
 					it('should have the second signature', () => {
-						return signedTransaction.should.have
-							.property('signSignature')
+						return expect(signedTransaction)
+							.to.have.property('signSignature')
 							.be.equal(signSignature);
 					});
 
 					it('should have the id', () => {
-						return signedTransaction.should.have
-							.property('id')
+						return expect(signedTransaction)
+							.to.have.property('id')
 							.be.equal(secondSignedTransactionId);
 					});
 
 					it('should use time.getTimeWithOffset to calculate the timestamp', () => {
-						return getTimeWithOffsetStub.should.be.calledWithExactly(undefined);
+						return expect(getTimeWithOffsetStub).to.be.calledWithExactly(
+							undefined,
+						);
 					});
 				});
 
@@ -244,7 +262,7 @@ describe('#signRawTransaction', () => {
 						});
 
 						it('should calculate the time with the time offset', () => {
-							return getTimeWithOffsetStub.should.be.calledWithExactly(
+							return expect(getTimeWithOffsetStub).to.be.calledWithExactly(
 								timeOffset,
 							);
 						});
@@ -302,30 +320,30 @@ describe('#signRawTransaction', () => {
 			});
 
 			it('should sign the transaction', () => {
-				return signedTransaction.should.be.ok;
+				return expect(signedTransaction).to.be.ok;
 			});
 
 			it('should have the updated senderPublicKey', () => {
-				return signedTransaction.should.have
-					.property('senderPublicKey')
+				return expect(signedTransaction)
+					.to.have.property('senderPublicKey')
 					.equal(updatedSignerPublicKey);
 			});
 
 			it('should have the updated senderId', () => {
-				return signedTransaction.should.have
-					.property('senderId')
+				return expect(signedTransaction)
+					.to.have.property('senderId')
 					.equal(updatedSignerAddress);
 			});
 
 			it('should have the updated transactionId', () => {
-				return signedTransaction.should.have
-					.property('id')
+				return expect(signedTransaction)
+					.to.have.property('id')
 					.equal(updatedSignerId);
 			});
 
 			it('should have the updated signature', () => {
-				return signedTransaction.should.have
-					.property('signature')
+				return expect(signedTransaction)
+					.to.have.property('signature')
 					.equal(updatedSignerSignature);
 			});
 		});

--- a/test/transactions/utils/time.js
+++ b/test/transactions/utils/time.js
@@ -33,14 +33,14 @@ describe('time module', () => {
 		it('should return current time as number', () => {
 			const time = getTimeFromBlockchainEpoch();
 
-			return time.should.be.equal(nowEpochTime);
+			return expect(time).to.be.equal(nowEpochTime);
 		});
 
 		it('should return epoch time for provided time as number, equal to 10', () => {
 			const realTime = 1464109210001;
 			const time = getTimeFromBlockchainEpoch(realTime);
 
-			return time.should.be.equal(10);
+			return expect(time).to.be.equal(10);
 		});
 	});
 
@@ -48,21 +48,21 @@ describe('time module', () => {
 		it('should get time with undefined offset', () => {
 			const time = getTimeWithOffset();
 
-			return time.should.be.equal(nowEpochTime);
+			return expect(time).to.be.equal(nowEpochTime);
 		});
 
 		it('should get time with positive offset', () => {
 			const offset = 3;
 			const time = getTimeWithOffset(offset);
 
-			return time.should.be.equal(23);
+			return expect(time).to.be.equal(23);
 		});
 
 		it('should get time with negative offset', () => {
 			const offset = -3;
 			const time = getTimeWithOffset(offset);
 
-			return time.should.be.equal(17);
+			return expect(time).to.be.equal(17);
 		});
 	});
 });

--- a/test/transactions/utils/validation.js
+++ b/test/transactions/utils/validation.js
@@ -27,9 +27,9 @@ describe('public key validation', () => {
 			const invalidHexPublicKey =
 				'215b667a32a5cd51a94c9c2046c11fffb08c65748febec099451e3b164452bc';
 			it('should throw an error', () => {
-				return validatePublicKey
-					.bind(null, invalidHexPublicKey)
-					.should.throw('Argument must have a valid length of hex string.');
+				return expect(
+					validatePublicKey.bind(null, invalidHexPublicKey),
+				).to.throw('Argument must have a valid length of hex string.');
 			});
 		});
 
@@ -37,9 +37,9 @@ describe('public key validation', () => {
 			const invalidHexPublicKey =
 				'12345678123456781234567812345678123456781234567812345678123456gg';
 			it('should throw an error', () => {
-				return validatePublicKey
-					.bind(null, invalidHexPublicKey)
-					.should.throw('Argument must be a valid hex string.');
+				return expect(
+					validatePublicKey.bind(null, invalidHexPublicKey),
+				).to.throw('Argument must be a valid hex string.');
 			});
 		});
 
@@ -47,11 +47,9 @@ describe('public key validation', () => {
 			const tooLongPublicKey =
 				'215b667a32a5cd51a94c9c2046c11fffb08c65748febec099451e3b164452bca12';
 			it('should throw an error', () => {
-				return validatePublicKey
-					.bind(null, tooLongPublicKey)
-					.should.throw(
-						'Public key 215b667a32a5cd51a94c9c2046c11fffb08c65748febec099451e3b164452bca12 length differs from the expected 32 bytes for a public key.',
-					);
+				return expect(validatePublicKey.bind(null, tooLongPublicKey)).to.throw(
+					'Public key 215b667a32a5cd51a94c9c2046c11fffb08c65748febec099451e3b164452bca12 length differs from the expected 32 bytes for a public key.',
+				);
 			});
 		});
 
@@ -59,11 +57,9 @@ describe('public key validation', () => {
 			const tooShortPublicKey =
 				'215b667a32a5cd51a94c9c2046c11fffb08c65748febec099451e3b164452b';
 			it('should throw an error', () => {
-				return validatePublicKey
-					.bind(null, tooShortPublicKey)
-					.should.throw(
-						'Public key 215b667a32a5cd51a94c9c2046c11fffb08c65748febec099451e3b164452b length differs from the expected 32 bytes for a public key.',
-					);
+				return expect(validatePublicKey.bind(null, tooShortPublicKey)).to.throw(
+					'Public key 215b667a32a5cd51a94c9c2046c11fffb08c65748febec099451e3b164452b length differs from the expected 32 bytes for a public key.',
+				);
 			});
 		});
 
@@ -71,7 +67,7 @@ describe('public key validation', () => {
 			const publicKey =
 				'215b667a32a5cd51a94c9c2046c11fffb08c65748febec099451e3b164452bca';
 			it('should return true', () => {
-				return validatePublicKey(publicKey).should.be.true;
+				return expect(validatePublicKey(publicKey)).to.be.true;
 			});
 		});
 
@@ -79,7 +75,7 @@ describe('public key validation', () => {
 			const publicKey =
 				'1234567812345678123456781234567812345678123456781234567812345678';
 			it('should return true', () => {
-				return validatePublicKey(publicKey).should.be.true;
+				return expect(validatePublicKey(publicKey)).to.be.true;
 			});
 		});
 	});
@@ -93,9 +89,9 @@ describe('public key validation', () => {
 				'215b667a32a5cd51a94c9c2046c11fffb08c65748febec099451e3b164452bc',
 			];
 			it('should throw an error', () => {
-				return validatePublicKeys
-					.bind(null, publicKeys)
-					.should.throw('Argument must have a valid length of hex string.');
+				return expect(validatePublicKeys.bind(null, publicKeys)).to.throw(
+					'Argument must have a valid length of hex string.',
+				);
 			});
 		});
 
@@ -106,7 +102,7 @@ describe('public key validation', () => {
 				'1234567812345678123456781234567812345678123456781234567812345678',
 			];
 			it('should return true', () => {
-				return validatePublicKeys(publicKeys).should.be.true;
+				return expect(validatePublicKeys(publicKeys)).to.be.true;
 			});
 		});
 	});
@@ -123,7 +119,7 @@ describe('public key validation', () => {
 				return Promise.resolve();
 			});
 			it('the validated keysgroup should return true', () => {
-				return validateKeysgroup(keysgroup).should.be.true;
+				return expect(validateKeysgroup(keysgroup)).to.be.true;
 			});
 		});
 
@@ -133,11 +129,9 @@ describe('public key validation', () => {
 				return Promise.resolve();
 			});
 			it('should throw the error', () => {
-				return validateKeysgroup
-					.bind(null, keysgroup)
-					.should.throw(
-						'Expected between 1 and 16 public keys in the keysgroup.',
-					);
+				return expect(validateKeysgroup.bind(null, keysgroup)).to.throw(
+					'Expected between 1 and 16 public keys in the keysgroup.',
+				);
 			});
 		});
 
@@ -154,11 +148,9 @@ describe('public key validation', () => {
 				return Promise.resolve();
 			});
 			it('should throw the error', () => {
-				return validateKeysgroup
-					.bind(null, keysgroup)
-					.should.throw(
-						'Expected between 1 and 16 public keys in the keysgroup.',
-					);
+				return expect(validateKeysgroup.bind(null, keysgroup)).to.throw(
+					'Expected between 1 and 16 public keys in the keysgroup.',
+				);
 			});
 		});
 	});
@@ -171,7 +163,7 @@ describe('public key validation', () => {
 				'5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09',
 			];
 			it('should return true', () => {
-				return checkPublicKeysForDuplicates(publicKeys).should.be.true;
+				return expect(checkPublicKeysForDuplicates(publicKeys)).to.be.true;
 			});
 		});
 
@@ -182,11 +174,11 @@ describe('public key validation', () => {
 				'922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa',
 			];
 			it('should throw', () => {
-				return checkPublicKeysForDuplicates
-					.bind(null, publicKeys)
-					.should.throw(
-						'Duplicated public key: 922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa.',
-					);
+				return expect(
+					checkPublicKeysForDuplicates.bind(null, publicKeys),
+				).to.throw(
+					'Duplicated public key: 922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa.',
+				);
 			});
 		});
 	});
@@ -201,7 +193,7 @@ describe('public key validation', () => {
 
 			it('should return true', () => {
 				return addresses.forEach(address => {
-					return validateAddress(address).should.be.true;
+					return expect(validateAddress(address)).to.be.true;
 				});
 			});
 		});
@@ -212,7 +204,7 @@ describe('public key validation', () => {
 				'Address length does not match requirements. Expected between 2 and 22 characters.';
 
 			it('should throw', () => {
-				return validateAddress.bind(null, address).should.throw(error);
+				return expect(validateAddress.bind(null, address)).to.throw(error);
 			});
 		});
 
@@ -222,7 +214,7 @@ describe('public key validation', () => {
 				'Address length does not match requirements. Expected between 2 and 22 characters.';
 
 			it('should throw', () => {
-				return validateAddress.bind(null, address).should.throw(error);
+				return expect(validateAddress.bind(null, address)).to.throw(error);
 			});
 		});
 
@@ -232,7 +224,7 @@ describe('public key validation', () => {
 				'Address format does not match requirements. Expected "L" at the end.';
 
 			it('should throw', () => {
-				return validateAddress.bind(null, address).should.throw(error);
+				return expect(validateAddress.bind(null, address)).to.throw(error);
 			});
 		});
 
@@ -242,7 +234,7 @@ describe('public key validation', () => {
 				'Address format does not match requirements. Address out of maximum range.';
 
 			it('should throw', () => {
-				return validateAddress.bind(null, address).should.throw(error);
+				return expect(validateAddress.bind(null, address)).to.throw(error);
 			});
 		});
 	});

--- a/test/transactions/utils/wrap_transaction_creator.js
+++ b/test/transactions/utils/wrap_transaction_creator.js
@@ -39,7 +39,7 @@ describe('#wrapTransactionCreator', () => {
 	});
 
 	it('should return a function', () => {
-		return wrappedTransactionCreator.should.have.a('function');
+		return expect(wrappedTransactionCreator).to.have.a('function');
 	});
 
 	describe('when a transaction is created with no passphrase', () => {
@@ -49,23 +49,27 @@ describe('#wrapTransactionCreator', () => {
 		});
 
 		it('should set a default amount of 0', () => {
-			return result.should.have.property('amount').equal('0');
+			return expect(result)
+				.to.have.property('amount')
+				.equal('0');
 		});
 
 		it('should set a default recipientId of null', () => {
-			return result.should.have.property('recipientId').be.null;
+			return expect(result).to.have.property('recipientId').be.null;
 		});
 
 		it('should set a default senderPublicKey of null', () => {
-			return result.should.have.property('senderPublicKey').be.null;
+			return expect(result).to.have.property('senderPublicKey').be.null;
 		});
 
 		it('should set a timestamp', () => {
-			return result.should.have.property('timestamp').have.a('number');
+			return expect(result)
+				.to.have.property('timestamp')
+				.have.a('number');
 		});
 
 		it('should not prepare the transaction', () => {
-			return prepareTransactionStub.should.not.have.been.called;
+			return expect(prepareTransactionStub).not.to.have.been.called;
 		});
 	});
 
@@ -84,12 +88,14 @@ describe('#wrapTransactionCreator', () => {
 		});
 
 		it('should have the amount', () => {
-			return result.should.have.property('amount').equal(defaultAmount);
+			return expect(result)
+				.to.have.property('amount')
+				.equal(defaultAmount);
 		});
 
 		it('should have the recipientId', () => {
-			return result.should.have
-				.property('recipientId')
+			return expect(result)
+				.to.have.property('recipientId')
 				.equal(defaultRecipientId);
 		});
 	});
@@ -101,25 +107,31 @@ describe('#wrapTransactionCreator', () => {
 		});
 
 		it('should set a default amount of 0', () => {
-			return result.should.have.property('amount').equal('0');
+			return expect(result)
+				.to.have.property('amount')
+				.equal('0');
 		});
 
 		it('should set a default recipientId of null', () => {
-			return result.should.have.property('recipientId').be.null;
+			return expect(result).to.have.property('recipientId').be.null;
 		});
 
 		it('should set a default senderPublicKey using the passphrase', () => {
-			return result.should.have
-				.property('senderPublicKey')
+			return expect(result)
+				.to.have.property('senderPublicKey')
 				.equal(defaultSenderPublicKey);
 		});
 
 		it('should set a timestamp', () => {
-			return result.should.have.property('timestamp').have.a('number');
+			return expect(result)
+				.to.have.property('timestamp')
+				.have.a('number');
 		});
 
 		it('should prepare the transaction with the passphrase', () => {
-			return prepareTransactionStub.args[0][1].should.equal(defaultPassphrase);
+			return expect(prepareTransactionStub.args[0][1]).to.equal(
+				defaultPassphrase,
+			);
 		});
 	});
 
@@ -133,27 +145,32 @@ describe('#wrapTransactionCreator', () => {
 		});
 
 		it('should set a default amount of 0', () => {
-			return result.should.have.property('amount').equal('0');
+			return expect(result)
+				.to.have.property('amount')
+				.equal('0');
 		});
 
 		it('should set a default recipientId of null', () => {
-			return result.should.have.property('recipientId').be.null;
+			return expect(result).to.have.property('recipientId').be.null;
 		});
 
 		it('should set a default senderPublicKey using the passphrase', () => {
-			return result.should.have
-				.property('senderPublicKey')
+			return expect(result)
+				.to.have.property('senderPublicKey')
 				.equal(defaultSenderPublicKey);
 		});
 
 		it('should set a timestamp', () => {
-			return result.should.have.property('timestamp').have.a('number');
+			return expect(result)
+				.to.have.property('timestamp')
+				.have.a('number');
 		});
 
 		it('should prepare the transaction with the passphrase and the second passphrase', () => {
-			return prepareTransactionStub.args[0]
-				.slice(1)
-				.should.eql([defaultPassphrase, defaultSecondPassphrase]);
+			return expect(prepareTransactionStub.args[0].slice(1)).to.eql([
+				defaultPassphrase,
+				defaultSecondPassphrase,
+			]);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?
Following Lisk-template, testing suite should use `expect`

### How did I fix it?
convert all the test to use `expect` syntax

### How to test it?
`npm test`

### Review checklist

* The PR solves #576 
* Merge After #596 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
