### PR TITLE
Update retry policy - Closes #587

### DIFF
--- a/src/api_client/api_resource.js
+++ b/src/api_client/api_resource.js
@@ -14,7 +14,7 @@
  */
 
 import * as popsicle from 'popsicle';
-import { MAX_RETRY_COUNT } from './constants';
+import { API_RECONNECT_MAX_RETRY_COUNT } from './constants';
 
 export default class APIResource {
 	constructor(apiClient) {
@@ -52,7 +52,7 @@ export default class APIResource {
 			return new Promise(resolve => setTimeout(resolve, 1000)).then(() => {
 				if (this.apiClient.randomizeNodes) {
 					this.apiClient.banActiveNodeAndSelect();
-				} else if (retryCount > MAX_RETRY_COUNT) {
+				} else if (retryCount > API_RECONNECT_MAX_RETRY_COUNT) {
 					throw error;
 				}
 				return this.request(req, true, retryCount + 1);

--- a/src/api_client/api_resource.js
+++ b/src/api_client/api_resource.js
@@ -14,6 +14,7 @@
  */
 
 import * as popsicle from 'popsicle';
+import { MAX_RETRY_COUNT } from './constants';
 
 export default class APIResource {
 	constructor(apiClient) {
@@ -34,31 +35,29 @@ export default class APIResource {
 		return `${this.apiClient.currentNode}/api${this.path}`;
 	}
 
-	request(req, retry) {
+	request(req, retry, retryCount = 1) {
 		const request = popsicle
 			.request(req)
 			.use(popsicle.plugins.parse(['json', 'urlencoded']))
 			.then(res => res.body);
 
 		if (retry) {
-			request.catch(err => this.handleRetry(err, req));
+			request.catch(err => this.handleRetry(err, req, retryCount));
 		}
 		return request;
 	}
 
-	handleRetry(error, req) {
+	handleRetry(error, req, retryCount) {
 		if (this.apiClient.hasAvailableNodes()) {
 			return new Promise(resolve => setTimeout(resolve, 1000)).then(() => {
 				if (this.apiClient.randomizeNodes) {
 					this.apiClient.banActiveNodeAndSelect();
+				} else if (retryCount > MAX_RETRY_COUNT) {
+					throw error;
 				}
-				return this.request(req, true);
+				return this.request(req, true, retryCount + 1);
 			});
 		}
-		return Promise.resolve({
-			success: false,
-			error,
-			message: 'Could not create an HTTP request to any known nodes.',
-		});
+		throw error;
 	}
 }

--- a/src/api_client/api_resource.js
+++ b/src/api_client/api_resource.js
@@ -58,6 +58,6 @@ export default class APIResource {
 				return this.request(req, true, retryCount + 1);
 			});
 		}
-		throw error;
+		return Promise.reject(error);
 	}
 }

--- a/src/api_client/constants.js
+++ b/src/api_client/constants.js
@@ -15,3 +15,4 @@
 export const GET = 'GET';
 export const POST = 'POST';
 export const PUT = 'PUT';
+export const MAX_RETRY_COUNT = 3;

--- a/src/api_client/constants.js
+++ b/src/api_client/constants.js
@@ -15,4 +15,4 @@
 export const GET = 'GET';
 export const POST = 'POST';
 export const PUT = 'PUT';
-export const MAX_RETRY_COUNT = 3;
+export const API_RECONNECT_MAX_RETRY_COUNT = 3;

--- a/test/api_client/api_resource.js
+++ b/test/api_client/api_resource.js
@@ -91,7 +91,7 @@ describe('API resource module', () => {
 		let defaultError;
 
 		beforeEach(() => {
-			defaultError = new Error('network error');
+			defaultError = new Error('could not connect to a node');
 			popsicleStub = sandbox.stub(popsicle, 'request').returns({
 				use: () => Promise.resolve(sendRequestResult),
 			});
@@ -131,7 +131,7 @@ describe('API resource module', () => {
 		let requestStub;
 		let defaultError;
 		beforeEach(() => {
-			defaultError = new Error('network error');
+			defaultError = new Error('could not connect to a node');
 			requestStub = sandbox
 				.stub(resource, 'request')
 				.returns(Promise.resolve(sendRequestResult.body));
@@ -188,9 +188,9 @@ describe('API resource module', () => {
 			});
 
 			it('should throw an error that is the same as input error', () => {
-				return expect(resource.handleRetry
-					.bind(resource, defaultError, defaultRequest, 1))
-					.to.throw(defaultError);
+				return expect(
+					resource.handleRetry.bind(resource, defaultError, defaultRequest, 1),
+				).to.throw(defaultError);
 			});
 		});
 	});

--- a/test/api_client/api_resource.js
+++ b/test/api_client/api_resource.js
@@ -173,7 +173,7 @@ describe('API resource module', () => {
 				});
 			});
 
-			it('should throw an error when randomizeNodes is false and if it exceed max retry count', () => {
+			it('should throw an error when randomizeNodes is false and the maximum retry count has been reached', () => {
 				apiClient.randomizeNodes = false;
 				const req = resource.handleRetry(defaultError, defaultRequest, 4);
 				clock.tick(1000);
@@ -188,9 +188,8 @@ describe('API resource module', () => {
 			});
 
 			it('should throw an error that is the same as input error', () => {
-				return expect(
-					resource.handleRetry.bind(resource, defaultError, defaultRequest, 1),
-				).to.throw(defaultError);
+				const res = resource.handleRetry(defaultError, defaultRequest, 1);
+				return expect(res).to.be.rejectedWith(defaultError);
 			});
 		});
 	});

--- a/test/api_client/api_resource.js
+++ b/test/api_client/api_resource.js
@@ -30,7 +30,6 @@ describe('API resource module', () => {
 		minVersion: '>=0.5.0',
 		port: '443',
 	};
-	const defaultError = new Error('network error');
 	const defaultRequest = {
 		method: GET,
 		url: defaultFullPath,
@@ -89,8 +88,10 @@ describe('API resource module', () => {
 	describe('#request', () => {
 		let popsicleStub;
 		let handleRetryStub;
+		let defaultError;
 
 		beforeEach(() => {
+			defaultError = new Error('network error');
 			popsicleStub = sandbox.stub(popsicle, 'request').returns({
 				use: () => Promise.resolve(sendRequestResult),
 			});
@@ -128,7 +129,9 @@ describe('API resource module', () => {
 
 	describe('#handleRetry', () => {
 		let requestStub;
+		let defaultError;
 		beforeEach(() => {
+			defaultError = new Error('network error');
 			requestStub = sandbox
 				.stub(resource, 'request')
 				.returns(Promise.resolve(sendRequestResult.body));
@@ -150,7 +153,7 @@ describe('API resource module', () => {
 
 			it('should call banActiveNode when randomizeNodes is true', () => {
 				apiClient.randomizeNodes = true;
-				const req = resource.handleRetry(defaultError, defaultRequest);
+				const req = resource.handleRetry(defaultError, defaultRequest, 1);
 				clock.tick(1000);
 				return req.then(res => {
 					expect(apiClient.banActiveNodeAndSelect).to.be.calledOnce;
@@ -161,13 +164,20 @@ describe('API resource module', () => {
 
 			it('should not call ban active node when randomizeNodes is false', () => {
 				apiClient.randomizeNodes = false;
-				const req = resource.handleRetry(defaultError, defaultRequest);
+				const req = resource.handleRetry(defaultError, defaultRequest, 1);
 				clock.tick(1000);
 				return req.then(res => {
 					expect(apiClient.banActiveNodeAndSelect).not.to.be.called;
 					expect(requestStub).to.be.calledWith(defaultRequest, true);
 					return expect(res).to.be.eql(sendRequestResult.body);
 				});
+			});
+
+			it('should throw an error when randomizeNodes is false and if it exceed max retry count', () => {
+				apiClient.randomizeNodes = false;
+				const req = resource.handleRetry(defaultError, defaultRequest, 4);
+				clock.tick(1000);
+				return expect(req).to.be.rejectedWith(defaultError);
 			});
 		});
 
@@ -177,13 +187,10 @@ describe('API resource module', () => {
 				return Promise.resolve();
 			});
 
-			it('should resolve with failure response', () => {
-				const req = resource.handleRetry(defaultError, defaultRequest);
-				return expect(req).eventually.to.eql({
-					success: false,
-					error: defaultError,
-					message: 'Could not create an HTTP request to any known nodes.',
-				});
+			it('should throw an error that is the same as input error', () => {
+				return expect(resource.handleRetry
+					.bind(resource, defaultError, defaultRequest, 1))
+					.to.throw(defaultError);
 			});
 		});
 	});

--- a/test/api_client/constants.js
+++ b/test/api_client/constants.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { GET, POST, PUT } from 'api_client/constants';
+import { GET, POST, PUT, MAX_RETRY_COUNT } from 'api_client/constants';
 
 describe('api constants module', () => {
 	it('GET should be a string', () => {
@@ -25,5 +25,9 @@ describe('api constants module', () => {
 
 	it('PUT should be a string', () => {
 		return expect(PUT).to.be.a('string');
+	});
+
+	it('MAX_RETRY_COUNT should be an integer', () => {
+		return MAX_RETRY_COUNT.should.be.an.integer;
 	});
 });

--- a/test/api_client/constants.js
+++ b/test/api_client/constants.js
@@ -12,7 +12,12 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { GET, POST, PUT, MAX_RETRY_COUNT } from 'api_client/constants';
+import {
+	GET,
+	POST,
+	PUT,
+	API_RECONNECT_MAX_RETRY_COUNT,
+} from 'api_client/constants';
 
 describe('api constants module', () => {
 	it('GET should be a string', () => {
@@ -27,7 +32,7 @@ describe('api constants module', () => {
 		return expect(PUT).to.be.a('string');
 	});
 
-	it('MAX_RETRY_COUNT should be an integer', () => {
-		return MAX_RETRY_COUNT.should.be.an.integer;
+	it('API_RECONNECT_MAX_RETRY_COUNT should be an integer', () => {
+		return expect(API_RECONNECT_MAX_RETRY_COUNT).to.be.an.integer;
 	});
 });


### PR DESCRIPTION
### What was the problem?
If randomizeNode was not set to true, it will retry forever to the same node.

### How did I fix it?
limit the number of try to 3, if randomizeNode is set to false.

### How to test it?
`npm test`

### Review checklist

* The PR solves #587 
* Merge after #596 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
