### PR TITLE
Update APIClient endpoint and function names - Closes #602

### DIFF
--- a/src/api_client/resources/accounts.js
+++ b/src/api_client/resources/accounts.js
@@ -27,13 +27,13 @@ export default class AccountsResource extends APIResource {
 			method: GET,
 		}).bind(this);
 
-		this.getMultisignatureGroup = apiMethod({
+		this.getMultisignatureGroups = apiMethod({
 			method: GET,
 			path: '/{address}/multisignature_groups',
 			urlParams: ['address'],
 		}).bind(this);
 
-		this.getMultisignatureMembership = apiMethod({
+		this.getMultisignatureMemberships = apiMethod({
 			method: GET,
 			path: '/{address}/multisignature_memberships',
 			urlParams: ['address'],

--- a/src/api_client/resources/delegates.js
+++ b/src/api_client/resources/delegates.js
@@ -39,9 +39,9 @@ export default class DelegatesResource extends APIResource {
 			path: '/forgers',
 		}).bind(this);
 
-		this.getForgingStats = apiMethod({
+		this.getForgingStatistics = apiMethod({
 			method: GET,
-			path: '/{address}/forging_stats',
+			path: '/{address}/forging_statistics',
 			urlParams: ['address'],
 		}).bind(this);
 	}

--- a/test/api_client/resources/accounts.js
+++ b/test/api_client/resources/accounts.js
@@ -62,15 +62,15 @@ describe('AccountsResource', () => {
 				.which.is.a('function');
 		});
 
-		it('should have a "getMultisignatureGroup" function', () => {
+		it('should have a "getMultisignatureGroups" function', () => {
 			return expect(resource)
-				.to.have.property('getMultisignatureGroup')
+				.to.have.property('getMultisignatureGroups')
 				.which.is.a('function');
 		});
 
-		it('should have a "getMultisignatureMembership" function', () => {
+		it('should have a "getMultisignatureMemberships" function', () => {
 			return expect(resource)
-				.to.have.property('getMultisignatureMembership')
+				.to.have.property('getMultisignatureMemberships')
 				.which.is.a('function');
 		});
 	});

--- a/test/api_client/resources/delegates.js
+++ b/test/api_client/resources/delegates.js
@@ -74,9 +74,9 @@ describe('DelegatesResource', () => {
 				.which.is.a('function');
 		});
 
-		it('should have a "getForgingStats" function', () => {
+		it('should have a "getForgingStatistics" function', () => {
 			return expect(resource)
-				.to.have.property('getForgingStats')
+				.to.have.property('getForgingStatistics')
 				.which.is.a('function');
 		});
 	});


### PR DESCRIPTION
### What was the problem?
- Update on APIEndpoint update on lisk-core
- Singular name of resource method even though API endpoints were plural.

### How did I fix it?
- Change API endpoint and fixed method name
- Update name to match API endpoints

### Review checklist

* The PR solves #602 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
