### PR TITLE
Add headed browsertest npm script - Closes #579

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"test:watch:min": "npm run test:watch -- --reporter=min",
 		"test:node": "npm run build:check && BABEL_ENV=buildcheck mocha test --recursive",
 		"test:browser": "cypress run --env ROOT_DIR=\"${PWD##*/}\"",
+		"test:browser:headed": "npm run test:browser -- --headed",
 		"cover": "if [ -z $JENKINS_HOME ]; then npm run cover:local; else npm run cover:ci; fi",
 		"cover:base": "NODE_ENV=test nyc report",
 		"cover:local": "npm run cover:base -- --reporter=html --reporter=text",


### PR DESCRIPTION
Closes #579

### What was the problem?

We didn't have a script for running browsertests in headed mode (useful for debugging).

### How did I fix it?

Added a script.

### How to test it?

`npm run test:browser:headed`

### Review checklist

* The PR solves #579 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
