### PR TITLE
Use chai-as-promised where possible - Closes #560

### DIFF
--- a/test/api_client/api_resource.js
+++ b/test/api_client/api_resource.js
@@ -179,12 +179,10 @@ describe('API resource module', () => {
 
 			it('should resolve with failure response', () => {
 				const req = resource.handleRetry(defaultError, defaultRequest);
-				return req.then(res => {
-					expect(res.success).to.be.false;
-					expect(res.error).to.eql(defaultError);
-					return expect(res.message).to.equal(
-						'Could not create an HTTP request to any known nodes.',
-					);
+				return expect(req).eventually.to.eql({
+					success: false,
+					error: defaultError,
+					message: 'Could not create an HTTP request to any known nodes.',
 				});
 			});
 		});


### PR DESCRIPTION
Closes #560

### What was the problem?

We weren't making use of chai-as-promised.

### How did I fix it?

I applied it where possible. The problem was in most cases we were making assertions on things other than the resolution value of the relevant promise, so chai-as-promised couldn't be used.

### How to test it?

`npm test`

### Review checklist

* The PR solves #560 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
