### PR TITLE
Add api client export to test

### DIFF
--- a/test/api_client/index.js
+++ b/test/api_client/index.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import APIClient from 'api_client';
+
+describe('api client', () => {
+	describe('exports', () => {
+		it('should have APIClient as a function', () => {
+			return expect(APIClient).to.be.a('function');
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

src/api_client/index.js did not have tests covering the exports

### How did I fix it?

Add tests to cover if it is exporting what we expect

### How to test it?

`npm test`

### Review checklist

* The PR solves #595
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
