### PR TITLE
Add check for buffer length passed to cryptography toAddress - Closes #607

### DIFF
--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -44,7 +44,17 @@ export const getFirstEightBytesReversed = publicKeyBytes =>
 		.slice(0, 8)
 		.reverse();
 
-export const toAddress = buffer => `${bufferToBigNumberString(buffer)}L`;
+export const toAddress = buffer => {
+	if (
+		!Buffer.from(buffer)
+			.slice(0, 8)
+			.equals(buffer)
+	)
+		throw new Error(
+			'The buffer for Lisk addresses must not have more than 8 bytes',
+		);
+	return `${bufferToBigNumberString(buffer)}L`;
+};
 
 export const getAddressFromPublicKey = publicKey => {
 	const publicKeyHash = hash(publicKey, 'hex');

--- a/test/cryptography/convert.js
+++ b/test/cryptography/convert.js
@@ -141,6 +141,15 @@ describe('convert', () => {
 			const address = toAddress(bufferInit);
 			return expect(address).to.be.eql(defaultAddressFromBuffer);
 		});
+
+		it('should throw on more than 8 bytes as input', () => {
+			const bufferExceedError =
+				'The buffer for Lisk addresses must not have more than 8 bytes';
+			const bufferInit = Buffer.from(defaultStringWithMoreThanEightCharacters);
+			return expect(toAddress.bind(null, bufferInit)).to.throw(
+				bufferExceedError,
+			);
+		});
 	});
 
 	describe('#getAddressFromPublicKey', () => {


### PR DESCRIPTION
### What was the problem?

cryptography.toAddress did not have any input validation

### How did I fix it?

Adding validation for buffer !== Buffer.from(buffer).slice(0, 8)

### How to test it?

`npm test`

### Review checklist

* The PR solves #607
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
