### PR TITLE
Rename locate whitespaces to locate consecutive whitespaces

### DIFF
--- a/src/passphrase/validation.js
+++ b/src/passphrase/validation.js
@@ -40,7 +40,7 @@ export const locateUppercaseCharacters = passphrase => {
 	return positions;
 };
 
-export const locateWhitespaces = passphrase => {
+export const locateConsecutiveWhitespaces = passphrase => {
 	const positions = [];
 	const passphraseLength = passphrase.length;
 	const lastIndex = passphraseLength - 1;
@@ -97,7 +97,7 @@ export const getPassphraseValidationErrors = (passphrase, wordlist) => {
 			}. Please check the passphrase.`,
 			expected: expectedWhitespaces,
 			actual: whiteSpacesInPassphrase,
-			location: locateWhitespaces(passphrase),
+			location: locateConsecutiveWhitespaces(passphrase),
 		};
 		errors.push(whiteSpaceError);
 	}

--- a/test/passphrase/validation.js
+++ b/test/passphrase/validation.js
@@ -19,7 +19,7 @@ import {
 	countPassphraseWords,
 	getPassphraseValidationErrors,
 	locateUppercaseCharacters,
-	locateWhitespaces,
+	locateConsecutiveWhitespaces,
 } from 'passphrase/validation';
 
 describe('passphrase validation', () => {
@@ -287,19 +287,23 @@ describe('passphrase validation', () => {
 		});
 	});
 
-	describe('locateWhitespaces', () => {
+	describe('locateConsecutiveWhitespaces', () => {
 		const emptyArray = [];
 		describe('given a string without whitespaces', () => {
 			const string = 'abcdefghijklkmnop';
 			it('should return an empty array', () => {
-				return expect(locateWhitespaces(string)).to.be.eql(emptyArray);
+				return expect(locateConsecutiveWhitespaces(string)).to.be.eql(
+					emptyArray,
+				);
 			});
 		});
 
 		describe('given a string with whitespaces', () => {
 			const string = 'abc defghijk lkmnop';
 			it('should return an empty array', () => {
-				return expect(locateWhitespaces(string)).to.be.eql(emptyArray);
+				return expect(locateConsecutiveWhitespaces(string)).to.be.eql(
+					emptyArray,
+				);
 			});
 		});
 
@@ -307,7 +311,7 @@ describe('passphrase validation', () => {
 			const string = ' abc defghijk lkmnop';
 			const expectedWhitespaceLocation = [0];
 			it('should return the array with the location of the whitespace', () => {
-				return expect(locateWhitespaces(string)).to.be.eql(
+				return expect(locateConsecutiveWhitespaces(string)).to.be.eql(
 					expectedWhitespaceLocation,
 				);
 			});
@@ -317,7 +321,7 @@ describe('passphrase validation', () => {
 			const string = 'abc defghijk lkmnop ';
 			const expectedWhitespaceLocation = [19];
 			it('should return the array with the location of the whitespace', () => {
-				return expect(locateWhitespaces(string)).to.be.eql(
+				return expect(locateConsecutiveWhitespaces(string)).to.be.eql(
 					expectedWhitespaceLocation,
 				);
 			});
@@ -327,7 +331,7 @@ describe('passphrase validation', () => {
 			const string = 'abc  defghijk  lkmnop ';
 			const expectedWhitespaceLocation = [4, 14, 21];
 			it('should return the array with the location of the whitespaces', () => {
-				return expect(locateWhitespaces(string)).to.be.eql(
+				return expect(locateConsecutiveWhitespaces(string)).to.be.eql(
 					expectedWhitespaceLocation,
 				);
 			});
@@ -337,7 +341,7 @@ describe('passphrase validation', () => {
 			const string = 'abc  defghijk\t \nlkmnop \u00A0';
 			const expectedWhitespaceLocation = [4, 14, 15, 23];
 			it('should return the array with the location of the whitespaces', () => {
-				return expect(locateWhitespaces(string)).to.be.eql(
+				return expect(locateConsecutiveWhitespaces(string)).to.be.eql(
 					expectedWhitespaceLocation,
 				);
 			});


### PR DESCRIPTION
### What was the problem?

Locate whitespaces was error prone since it looks for consecutive whitespaces, whitespaces are naturally part of mnemonic passphrases 

### How did I fix it?

Rename locateWhitespaces function to locateConsecutiveWhitespaces

### How to test it?

`npm test`

### Review checklist

* The PR solves #608
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
