### PR TITLE
Fix buffer allocation for dapp asset - Closes #616

### DIFF
--- a/src/transactions/utils/get_transaction_bytes.js
+++ b/src/transactions/utils/get_transaction_bytes.js
@@ -83,8 +83,10 @@ export const getAssetDataForCreateDappTransaction = ({ dapp }) => {
 	const { name, description, tags, link, icon, type, category } = dapp;
 	const nameBuffer = Buffer.from(name, 'utf8');
 	const linkBuffer = Buffer.from(link, 'utf8');
-	const typeBuffer = Buffer.alloc(4, type);
-	const categoryBuffer = Buffer.alloc(4, category);
+	const typeBuffer = Buffer.alloc(4);
+	typeBuffer.writeIntLE(type, 0);
+	const categoryBuffer = Buffer.alloc(4);
+	categoryBuffer.writeIntLE(category, 0);
 
 	const descriptionBuffer = description
 		? Buffer.from(description, 'utf8')


### PR DESCRIPTION
### What was the problem?
Dapp transactionId did not match to `lisk-core`.
When we create the buffer for the asset field for Dapp, we were doing
```
const typeBuffer = Buffer.alloc(4, type);
const categoryBuffer = Buffer.alloc(4, category);
```
This would fill each byte with the second argument of the `alloc`
```
Buffer.alloc(4, 3)
<Buffer 03 03 03 03>
```
However what `lisk-core` was expecting was
```
<Buffer 03 00 00 00>
```
which is done in [here](https://github.com/LiskHQ/lisk/blob/ab613eb7da7952169a1457cd1274c588612152be/logic/dapp.js#L287-L290)

### How did I fix it?
Instead of allocating to each bytes,
```
const categoryBuffer = Buffer.alloc(4);
categoryBuffer.writeIntLE(category, 0);
```
### How to test it?
Create transaction and send it to lisk-core

### Review checklist

* The PR solves #616 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
