### PR TITLE
Fix default recipientId to be empty string - Closes #614

### DIFF
--- a/src/transactions/utils/wrap_transaction_creator.js
+++ b/src/transactions/utils/wrap_transaction_creator.js
@@ -27,7 +27,7 @@ const wrapTransactionCreator = transactionCreator => transactionParameters => {
 	const transaction = Object.assign(
 		{
 			amount: '0',
-			recipientId: null,
+			recipientId: '',
 			senderPublicKey,
 			timestamp,
 		},

--- a/test/transactions/1_register_second_passphrase.js
+++ b/test/transactions/1_register_second_passphrase.js
@@ -97,10 +97,10 @@ describe('#registerSecondPassphrase transaction', () => {
 				.and.equal(secondPassphraseFee);
 		});
 
-		it('should have recipientId equal to null', () => {
-			return expect(registerSecondPassphraseTransaction).to.have.property(
-				'recipientId',
-			).and.be.null;
+		it('should have recipientId equal to empty string', () => {
+			return expect(registerSecondPassphraseTransaction)
+				.to.have.property('recipientId')
+				.and.equal('');
 		});
 
 		it('should have senderPublicKey hex string equal to sender public key', () => {
@@ -202,7 +202,7 @@ describe('#registerSecondPassphrase transaction', () => {
 			it('should have the recipient', () => {
 				return expect(registerSecondPassphraseTransaction)
 					.to.have.property('recipientId')
-					.equal(null);
+					.equal('');
 			});
 
 			it('should have the sender public key', () => {

--- a/test/transactions/2_register_delegate.js
+++ b/test/transactions/2_register_delegate.js
@@ -93,9 +93,10 @@ describe('#registerDelegate transaction', () => {
 				.and.equal(fee);
 		});
 
-		it('should have recipientId equal to null', () => {
-			return expect(registerDelegateTransaction).to.have.property('recipientId')
-				.and.be.null;
+		it('should have recipientId equal to empty string', () => {
+			return expect(registerDelegateTransaction)
+				.to.have.property('recipientId')
+				.and.equal('');
 		});
 
 		it('should have senderPublicKey hex string equal to sender public key', () => {
@@ -190,7 +191,7 @@ describe('#registerDelegate transaction', () => {
 			it('should have the recipient id', () => {
 				return expect(registerDelegateTransaction)
 					.to.have.property('recipientId')
-					.equal(null);
+					.equal('');
 			});
 
 			it('should have the sender public key', () => {

--- a/test/transactions/4_register_multisignature_account.js
+++ b/test/transactions/4_register_multisignature_account.js
@@ -121,10 +121,10 @@ describe('#registerMultisignatureAccount transaction', () => {
 					.and.equal(fee);
 			});
 
-			it('should have recipientId string equal to null', () => {
-				return expect(registerMultisignatureTransaction).to.have.property(
-					'recipientId',
-				).and.be.null;
+			it('should have recipientId string equal to empty string', () => {
+				return expect(registerMultisignatureTransaction)
+					.to.have.property('recipientId')
+					.and.equal('');
 			});
 
 			it('should have senderPublicKey hex string equal to sender public key', () => {
@@ -333,7 +333,7 @@ describe('#registerMultisignatureAccount transaction', () => {
 			it('should have the recipient id', () => {
 				return expect(registerMultisignatureTransaction)
 					.to.have.property('recipientId')
-					.equal(null);
+					.equal('');
 			});
 
 			it('should have the sender public key', () => {

--- a/test/transactions/5_create_dapp.js
+++ b/test/transactions/5_create_dapp.js
@@ -176,9 +176,10 @@ describe('#createDapp transaction', () => {
 					.and.equal(fee);
 			});
 
-			it('should have recipientId equal to null', () => {
-				return expect(createDappTransaction).to.have.property('recipientId').and
-					.be.null;
+			it('should have recipientId equal to empty string', () => {
+				return expect(createDappTransaction)
+					.to.have.property('recipientId')
+					.and.equal('');
 			});
 
 			it('should have senderPublicKey hex string equal to sender public key', () => {
@@ -315,7 +316,7 @@ describe('#createDapp transaction', () => {
 			it('should have the recipient id', () => {
 				return expect(createDappTransaction)
 					.to.have.property('recipientId')
-					.equal(null);
+					.equal('');
 			});
 
 			it('should have the sender public key', () => {

--- a/test/transactions/6_transfer_into_dapp.js
+++ b/test/transactions/6_transfer_into_dapp.js
@@ -95,10 +95,10 @@ describe('#transferIntoDapp transaction', () => {
 					.and.equal(transferFee);
 			});
 
-			it('should have recipientId equal to null', () => {
-				return expect(transferIntoDappTransaction).to.have.property(
-					'recipientId',
-				).be.null;
+			it('should have recipientId equal to empty string', () => {
+				return expect(transferIntoDappTransaction)
+					.to.have.property('recipientId')
+					.and.equal('');
 			});
 
 			it('should have senderPublicKey hex string equal to sender public key', () => {
@@ -191,7 +191,7 @@ describe('#transferIntoDapp transaction', () => {
 			it('should have the recipient id', () => {
 				return expect(transferIntoDappTransaction)
 					.to.have.property('recipientId')
-					.equal(null);
+					.equal('');
 			});
 
 			it('should have the sender public key', () => {

--- a/test/transactions/utils/wrap_transaction_creator.js
+++ b/test/transactions/utils/wrap_transaction_creator.js
@@ -54,8 +54,10 @@ describe('#wrapTransactionCreator', () => {
 				.equal('0');
 		});
 
-		it('should set a default recipientId of null', () => {
-			return expect(result).to.have.property('recipientId').be.null;
+		it('should set a default recipientId of empty string', () => {
+			return expect(result)
+				.to.have.property('recipientId')
+				.and.equal('');
 		});
 
 		it('should set a default senderPublicKey of null', () => {
@@ -112,8 +114,10 @@ describe('#wrapTransactionCreator', () => {
 				.equal('0');
 		});
 
-		it('should set a default recipientId of null', () => {
-			return expect(result).to.have.property('recipientId').be.null;
+		it('should set a default recipientId of empty string', () => {
+			return expect(result)
+				.to.have.property('recipientId')
+				.and.equal('');
 		});
 
 		it('should set a default senderPublicKey using the passphrase', () => {
@@ -150,8 +154,10 @@ describe('#wrapTransactionCreator', () => {
 				.equal('0');
 		});
 
-		it('should set a default recipientId of null', () => {
-			return expect(result).to.have.property('recipientId').be.null;
+		it('should set a default recipientId of empty string', () => {
+			return expect(result)
+				.to.have.property('recipientId')
+				.and.equal('');
 		});
 
 		it('should set a default senderPublicKey using the passphrase', () => {


### PR DESCRIPTION
### What was the problem?
Lisk-core sets `recipientId` as required field of string, on all the transaction related API.
Therefore, creating transaction with `null` will not pass the API validation.
#615 attempted to fix it for transaction type 2, but it applies to transactions `1, 2, 4, 5, 6`, therefore, more generic solution was needed

### How did I fix it?
Change default value of transaction to be `empty string`

### How to test it?
`npm test`
create each transaction of type 1, 2, 4, 5, and 6, then send it to core `1.0.0` API.

### Review checklist

* The PR solves #614 
* The PR is different approach of #615 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
