### PR TITLE
Change APIClient to throw error when API returns non 2xx - Closes #621

### DIFF
--- a/src/api_client/api_resource.js
+++ b/src/api_client/api_resource.js
@@ -42,9 +42,11 @@ export default class APIResource {
 			.then(res => {
 				if (res.status >= 300) {
 					if (res.body && res.body.message) {
-						throw new Error(res.body.message);
+						throw new Error(`Status ${res.status} : ${res.body.message}`);
 					}
-					throw new Error('An unknown error has occurred.');
+					throw new Error(
+						`Status ${res.status} : An unknown error has occurred.`,
+					);
 				}
 				return res.body;
 			});

--- a/src/api_client/api_resource.js
+++ b/src/api_client/api_resource.js
@@ -39,7 +39,15 @@ export default class APIResource {
 		const request = popsicle
 			.request(req)
 			.use(popsicle.plugins.parse(['json', 'urlencoded']))
-			.then(res => res.body);
+			.then(res => {
+				if (res.status >= 300) {
+					if (res.body && res.body.message) {
+						throw new Error(res.body.message);
+					}
+					throw new Error('An unknown error has occurred.');
+				}
+				return res.body;
+			});
 
 		if (retry) {
 			request.catch(err => this.handleRetry(err, req, retryCount));

--- a/test/api_client/api_resource.js
+++ b/test/api_client/api_resource.js
@@ -116,30 +116,36 @@ describe('API resource module', () => {
 
 		describe('when response status is greater than 300', () => {
 			it('should reject with "An unknown error has occured." message if there is no message is supplied', () => {
+				const statusCode = 300;
 				popsicleStub.returns({
 					use: () =>
 						Promise.resolve({
-							status: 300,
+							status: statusCode,
 						}),
 				});
 				return resource.request(defaultRequest, true).catch(err => {
-					return expect(err.message).to.equal('An unknown error has occurred.');
+					return expect(err.message).to.equal(
+						`Status ${statusCode} : An unknown error has occurred.`,
+					);
 				});
 			});
 
 			it('should reject with error message from server if message is supplied', () => {
 				const serverErrorMessage = 'validation error';
+				const statusCode = 300;
 				popsicleStub.returns({
 					use: () =>
 						Promise.resolve({
-							status: 300,
+							status: statusCode,
 							body: {
 								message: serverErrorMessage,
 							},
 						}),
 				});
 				return resource.request(defaultRequest, true).catch(err => {
-					return expect(err.message).to.eql(serverErrorMessage);
+					return expect(err.message).to.eql(
+						`Status ${statusCode} : ${serverErrorMessage}`,
+					);
 				});
 			});
 


### PR DESCRIPTION
### What was the problem?
When APIClient gets non-2xx status code, it does not throw an error.
If we return the body as the way currently work, there is no good way to check if it is an error or not from user.

### How did I fix it?
Check if the status code is greater than 300 (>= 300), then if it's 300 then throw an error.
If API supplies error message, throw an error with the message.
If not, return with unknown error.

### How to test it?
`npm test` and try to use it with Lisk core 1.0.0

### Review checklist

* The PR solves #621
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
