### PR TITLE
Add betanet constants - Closes #628

### DIFF
--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -13,6 +13,8 @@
  *
  */
 import {
+	BETANET_NETHASH,
+	BETANET_NODES,
 	TESTNET_NETHASH,
 	TESTNET_NODES,
 	MAINNET_NETHASH,
@@ -72,6 +74,10 @@ export default class APIClient {
 
 	static createTestnetAPIClient(options) {
 		return new APIClient(TESTNET_NODES, TESTNET_NETHASH, options);
+	}
+
+	static createBetanetAPIClient(options) {
+		return new APIClient(BETANET_NODES, BETANET_NETHASH, options);
 	}
 
 	initialize(nodes, nethash, providedOptions = {}) {

--- a/src/lisk-constants/index.js
+++ b/src/lisk-constants/index.js
@@ -21,6 +21,15 @@ export const MAX_ADDRESS_NUMBER = '18446744073709551615';
 // Largest possible amount. Derived from bignum.fromBuffer(Buffer.from(new Array(8).fill(255))).
 export const MAX_TRANSACTION_AMOUNT = '18446744073709551615';
 
+export const BETANET_NETHASH =
+	'ef3844327d1fd0fc5785291806150c937797bdb34a748c9cd932b7e859e9ca0c';
+export const BETANET_NODES = [
+	'http://94.237.41.99:5000',
+	'http://209.50.52.217:5000',
+	'http://94.237.26.150:5000',
+	'http://83.136.249.102:5000',
+	'http://94.237.65.179:5000',
+];
 export const TESTNET_NETHASH =
 	'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba';
 export const TESTNET_NODES = ['http://testnet.lisk.io:7000'];

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -30,6 +30,15 @@ describe('APIClient module', () => {
 	const testnetHash =
 		'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba';
 	const testnetNodes = ['http://testnet.lisk.io:7000'];
+	const betanetHash =
+		'ef3844327d1fd0fc5785291806150c937797bdb34a748c9cd932b7e859e9ca0c';
+	const betanetNodes = [
+		'http://94.237.41.99:5000',
+		'http://209.50.52.217:5000',
+		'http://94.237.26.150:5000',
+		'http://83.136.249.102:5000',
+		'http://94.237.65.179:5000',
+	];
 	const defaultHeaders = {
 		'Content-Type': 'application/json',
 		nethash: mainnetHash,
@@ -117,6 +126,26 @@ describe('APIClient module', () => {
 
 		it('should be set to testnet hash', () => {
 			return expect(client.headers.nethash).to.equal(testnetHash);
+		});
+	});
+
+	describe('#createBetanetAPIClient', () => {
+		let client;
+		beforeEach(() => {
+			client = APIClient.createBetanetAPIClient();
+			return Promise.resolve();
+		});
+
+		it('should return APIClient instance', () => {
+			return expect(client).to.be.instanceof(APIClient);
+		});
+
+		it('should contain betanet nodes', () => {
+			return expect(client.nodes).to.eql(betanetNodes);
+		});
+
+		it('should be set to betanet hash', () => {
+			return expect(client.headers.nethash).to.equal(betanetHash);
 		});
 	});
 

--- a/test/lisk-constants/index.js
+++ b/test/lisk-constants/index.js
@@ -49,15 +49,17 @@ describe('lisk-constants', () => {
 		return expect(TESTNET_NETHASH).to.be.a('string');
 	});
 
-	it('TESTNET_NODES should be a string', () => {
-		return expect(TESTNET_NODES).to.be.an('array');
+	it('TESTNET_NODES should be an array of strings', () => {
+		expect(TESTNET_NODES).to.be.an('array');
+		return TESTNET_NODES.forEach(node => expect(node).to.be.a('string'));
 	});
 
 	it('MAINNET_NETHASH should be a string', () => {
 		return expect(MAINNET_NETHASH).to.be.a('string');
 	});
 
-	it('MAINNET_NODES should be a string', () => {
-		return expect(MAINNET_NODES).to.be.an('array');
+	it('MAINNET_NODES should be an array of strings', () => {
+		expect(MAINNET_NODES).to.be.an('array');
+		return MAINNET_NODES.forEach(node => expect(node).to.be.a('string'));
 	});
 });

--- a/test/lisk-constants/index.js
+++ b/test/lisk-constants/index.js
@@ -18,6 +18,8 @@ import {
 	EPOCH_TIME_MILLISECONDS,
 	MAX_ADDRESS_NUMBER,
 	MAX_TRANSACTION_AMOUNT,
+	BETANET_NETHASH,
+	BETANET_NODES,
 	TESTNET_NETHASH,
 	TESTNET_NODES,
 	MAINNET_NETHASH,
@@ -43,6 +45,15 @@ describe('lisk-constants', () => {
 
 	it('MAX_TRANSACTION_AMOUNT should be a string', () => {
 		return expect(MAX_TRANSACTION_AMOUNT).to.be.a('string');
+	});
+
+	it('BETANET_NETHASH should be a string', () => {
+		return expect(BETANET_NETHASH).to.be.a('string');
+	});
+
+	it('BETANET_NODES should be an array of strings', () => {
+		expect(BETANET_NODES).to.be.an('array');
+		return BETANET_NODES.forEach(node => expect(node).to.be.a('string'));
 	});
 
 	it('TESTNET_NETHASH should be a string', () => {


### PR DESCRIPTION
### What was the problem?

We didn't have constants for betanet. Or an API client.

### How did I fix it?

I added constants for betanet, and a helper function for creating an API client.

### How to test it?

`npm t`

### Review checklist

* The PR solves #628 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
