### PR TITLE
Rework getAddress - Closes #634

### DIFF
--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -65,8 +65,6 @@ export const getAddressFromPublicKey = publicKey => {
 	return address;
 };
 
-export const getAddress = getAddressFromPublicKey;
-
 export const convertPublicKeyEd2Curve = ed2curve.convertPublicKey;
 
 export const convertPrivateKeyEd2Curve = ed2curve.convertSecretKey;

--- a/src/cryptography/keys.js
+++ b/src/cryptography/keys.js
@@ -17,7 +17,6 @@ import hash from './hash';
 
 export const getPrivateAndPublicKeyBytesFromPassphrase = passphrase => {
 	const hashed = hash(passphrase, 'utf8');
-
 	const { signSk, signPk } = naclInstance.crypto_sign_seed_keypair(hashed);
 
 	return {
@@ -40,11 +39,16 @@ export const getPrivateAndPublicKeyFromPassphrase = passphrase => {
 export const getKeys = getPrivateAndPublicKeyFromPassphrase;
 
 export const getAddressAndPublicKeyFromPassphrase = passphrase => {
-	const accountKeys = getKeys(passphrase);
-	const accountAddress = getAddressFromPublicKey(accountKeys.publicKey);
+	const { publicKey } = getKeys(passphrase);
+	const address = getAddressFromPublicKey(publicKey);
 
 	return {
-		address: accountAddress,
-		publicKey: accountKeys.publicKey,
+		address,
+		publicKey,
 	};
+};
+
+export const getAddressFromPassphrase = passphrase => {
+	const { publicKey } = getKeys(passphrase);
+	return getAddressFromPublicKey(publicKey);
 };

--- a/src/cryptography/keys.js
+++ b/src/cryptography/keys.js
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { bufferToHex, getAddress } from './convert';
+import { bufferToHex, getAddressFromPublicKey } from './convert';
 import hash from './hash';
 
 export const getPrivateAndPublicKeyBytesFromPassphrase = passphrase => {
@@ -41,7 +41,7 @@ export const getKeys = getPrivateAndPublicKeyFromPassphrase;
 
 export const getAddressAndPublicKeyFromPassphrase = passphrase => {
 	const accountKeys = getKeys(passphrase);
-	const accountAddress = getAddress(accountKeys.publicKey);
+	const accountAddress = getAddressFromPublicKey(accountKeys.publicKey);
 
 	return {
 		address: accountAddress,

--- a/test/cryptography/convert.js
+++ b/test/cryptography/convert.js
@@ -18,7 +18,6 @@ import {
 	getFirstEightBytesReversed,
 	toAddress,
 	getAddressFromPublicKey,
-	getAddress,
 	convertPublicKeyEd2Curve,
 	convertPrivateKeyEd2Curve,
 	bigNumberToBuffer,
@@ -159,17 +158,6 @@ describe('convert', () => {
 
 		it('should generate address from publicKey', () => {
 			const address = getAddressFromPublicKey(defaultPublicKey);
-			return expect(address).to.be.equal(defaultAddress);
-		});
-	});
-
-	describe('#getAddress', () => {
-		beforeEach(() => {
-			return sandbox.stub(hash, 'default').returns(defaultPublicKeyHash);
-		});
-
-		it('should generate address from publicKey', () => {
-			const address = getAddress(defaultPublicKey);
 			return expect(address).to.be.equal(defaultAddress);
 		});
 	});

--- a/test/cryptography/keys.js
+++ b/test/cryptography/keys.js
@@ -17,6 +17,7 @@ import {
 	getPrivateAndPublicKeyBytesFromPassphrase,
 	getKeys,
 	getAddressAndPublicKeyFromPassphrase,
+	getAddressFromPassphrase,
 } from 'cryptography/keys';
 // Require is used for stubbing
 const convert = require('cryptography/convert');
@@ -30,9 +31,10 @@ describe('keys', () => {
 		'2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09';
 	const defaultPublicKey =
 		'5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09';
+	const defaultAddress = '16402986683325069355L';
 	const defaultAddressAndPublicKey = {
 		publicKey: defaultPublicKey,
-		address: '16402986683325069355L',
+		address: defaultAddress,
 	};
 
 	let bufferToHexStub;
@@ -118,6 +120,14 @@ describe('keys', () => {
 			return expect(
 				getAddressAndPublicKeyFromPassphrase(defaultPassphrase),
 			).to.eql(defaultAddressAndPublicKey);
+		});
+	});
+
+	describe('#getAddressFromPassphrase', () => {
+		it('should create correct address', () => {
+			return expect(getAddressFromPassphrase(defaultPassphrase)).to.equal(
+				defaultAddress,
+			);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

`getAddress` was a confusing function name, and was used on betanet to get the address from a passphrase, even though it expected a public key, resulting in loss of funds.

### How did I fix it?

I removed `getAddress` and added a specific `getAddressFromPassphrase` function.

### How to test it?

`npm start` and then `LiskJS.cryptography.getAddressFromPassphrase(myPassphrase)`

### Review checklist

* The PR solves #634 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
