### PR TITLE
Change nethash to optional - Closes #646

### DIFF
--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -40,6 +40,7 @@ const defaultOptions = {
 
 const commonHeaders = {
 	'Content-Type': 'application/json',
+	os: 'lisk-js-api',
 };
 
 export default class APIClient {
@@ -61,21 +62,21 @@ export default class APIClient {
 	static createMainnetAPIClient(options) {
 		return new APIClient(
 			MAINNET_NODES,
-			Object.assign({}, options, { nethash: MAINNET_NETHASH }),
+			Object.assign({}, { nethash: MAINNET_NETHASH }, options),
 		);
 	}
 
 	static createTestnetAPIClient(options) {
 		return new APIClient(
 			TESTNET_NODES,
-			Object.assign({}, options, { nethash: TESTNET_NETHASH }),
+			Object.assign({}, { nethash: TESTNET_NETHASH }, options),
 		);
 	}
 
 	static createBetanetAPIClient(options) {
 		return new APIClient(
 			BETANET_NODES,
-			Object.assign({}, options, { nethash: BETANET_NETHASH }),
+			Object.assign({}, { nethash: BETANET_NETHASH }, options),
 		);
 	}
 
@@ -84,11 +85,17 @@ export default class APIClient {
 			throw new Error('APIClient requires nodes for initialization.');
 		}
 
+		if (typeof providedOptions !== 'object' || Array.isArray(providedOptions)) {
+			throw new Error(
+				'APIClient requires the second parameter to be an object.',
+			);
+		}
+
 		const options = Object.assign({}, defaultOptions, providedOptions);
 
 		this.headers = options.nethash
 			? Object.assign({}, commonHeaders, { nethash: options.nethash })
-			: commonHeaders;
+			: Object.assign({}, commonHeaders);
 		this.nodes = nodes;
 		this.bannedNodes = [...(options.bannedNodes || [])];
 		this.currentNode = options.node || this.getNewNode();

--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -87,7 +87,7 @@ export default class APIClient {
 
 		if (typeof providedOptions !== 'object' || Array.isArray(providedOptions)) {
 			throw new Error(
-				'APIClient requires the second parameter to be an object.',
+				'APIClient takes an optional object as the second parameter.',
 			);
 		}
 

--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -35,26 +35,16 @@ import {
 
 const defaultOptions = {
 	bannedNode: [],
-	version: '1.0.0',
-	minVersion: '>=1.0.0',
 	randomizeNode: true,
 };
 
 const commonHeaders = {
 	'Content-Type': 'application/json',
-	os: 'lisk-js-api',
 };
 
-const getHeaders = (nethash, version, minVersion) =>
-	Object.assign({}, commonHeaders, {
-		nethash,
-		version,
-		minVersion,
-	});
-
 export default class APIClient {
-	constructor(nodes, nethash, providedOptions = {}) {
-		this.initialize(nodes, nethash, providedOptions);
+	constructor(nodes, providedOptions = {}) {
+		this.initialize(nodes, providedOptions);
 
 		this.accounts = new AccountsResource(this);
 		this.blocks = new BlocksResource(this);
@@ -69,29 +59,36 @@ export default class APIClient {
 	}
 
 	static createMainnetAPIClient(options) {
-		return new APIClient(MAINNET_NODES, MAINNET_NETHASH, options);
+		return new APIClient(
+			MAINNET_NODES,
+			Object.assign({}, options, { nethash: MAINNET_NETHASH }),
+		);
 	}
 
 	static createTestnetAPIClient(options) {
-		return new APIClient(TESTNET_NODES, TESTNET_NETHASH, options);
+		return new APIClient(
+			TESTNET_NODES,
+			Object.assign({}, options, { nethash: TESTNET_NETHASH }),
+		);
 	}
 
 	static createBetanetAPIClient(options) {
-		return new APIClient(BETANET_NODES, BETANET_NETHASH, options);
+		return new APIClient(
+			BETANET_NODES,
+			Object.assign({}, options, { nethash: BETANET_NETHASH }),
+		);
 	}
 
-	initialize(nodes, nethash, providedOptions = {}) {
+	initialize(nodes, providedOptions = {}) {
 		if (!Array.isArray(nodes) || nodes.length <= 0) {
 			throw new Error('APIClient requires nodes for initialization.');
 		}
 
-		if (typeof nethash !== 'string' || nethash === '') {
-			throw new Error('APIClient requires nethash for initialization.');
-		}
-
 		const options = Object.assign({}, defaultOptions, providedOptions);
 
-		this.headers = getHeaders(nethash, options.version, options.minVersion);
+		this.headers = options.nethash
+			? Object.assign({}, commonHeaders, { nethash: options.nethash })
+			: commonHeaders;
 		this.nodes = nodes;
 		this.bannedNodes = [...(options.bannedNodes || [])];
 		this.currentNode = options.node || this.getNewNode();

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -38,18 +38,11 @@ describe('APIClient module', () => {
 	];
 	const defaultHeaders = {
 		'Content-Type': 'application/json',
-		nethash: mainnetHash,
-		os: 'lisk-js-api',
-		version: '1.0.0',
-		minVersion: '>=1.0.0',
 	};
 
 	const customHeaders = {
 		'Content-Type': 'application/json',
 		nethash: testnetHash,
-		os: 'lisk-js-api',
-		version: '0.5.0',
-		minVersion: '>=0.1.0',
 	};
 
 	const localNode = 'http://localhost:7000';
@@ -62,7 +55,7 @@ describe('APIClient module', () => {
 	let apiClient;
 
 	beforeEach(() => {
-		apiClient = new APIClient(defaultNodes, mainnetHash);
+		apiClient = new APIClient(defaultNodes);
 		return Promise.resolve();
 	});
 
@@ -81,7 +74,7 @@ describe('APIClient module', () => {
 		});
 
 		it('should call initialize', () => {
-			apiClient = new APIClient(defaultNodes, mainnetHash);
+			apiClient = new APIClient(defaultNodes);
 			return expect(initializeStub).to.be.calledOnce;
 		});
 	});
@@ -168,24 +161,6 @@ describe('APIClient module', () => {
 			);
 		});
 
-		it('should throw an error if no second argument is passed to constructor', () => {
-			return expect(
-				apiClient.initialize.bind(apiClient, defaultNodes),
-			).to.throw(Error, 'APIClient requires nethash for initialization.');
-		});
-
-		it('should throw an error if second argument passed to constructor is not string', () => {
-			return expect(
-				apiClient.initialize.bind(apiClient, defaultNodes, 123),
-			).to.throw(Error, 'APIClient requires nethash for initialization.');
-		});
-
-		it('should throw an error if second argument passed to constructor is empty string', () => {
-			return expect(
-				apiClient.initialize.bind(apiClient, defaultNodes, ''),
-			).to.throw(Error, 'APIClient requires nethash for initialization.');
-		});
-
 		describe('headers', () => {
 			it('should set with passed nethash, with default options', () => {
 				return expect(apiClient)
@@ -194,9 +169,9 @@ describe('APIClient module', () => {
 			});
 
 			it('should set custom headers with supplied options', () => {
-				apiClient = new APIClient(defaultNodes, testnetHash, {
+				apiClient = new APIClient(defaultNodes, {
 					version: customHeaders.version,
-					minVersion: customHeaders.minVersion,
+					nethash: testnetHash,
 				});
 				return expect(apiClient)
 					.to.have.property('headers')
@@ -221,7 +196,7 @@ describe('APIClient module', () => {
 
 			it('should set bannedNodes when passed as an option', () => {
 				const bannedNodes = ['a', 'b'];
-				apiClient = new APIClient(defaultNodes, mainnetHash, { bannedNodes });
+				apiClient = new APIClient(defaultNodes, { bannedNodes });
 				return expect(apiClient)
 					.to.have.property('bannedNodes')
 					.be.eql(bannedNodes);
@@ -235,7 +210,7 @@ describe('APIClient module', () => {
 			});
 
 			it('should set with supplied node if node is specified by options', () => {
-				apiClient = new APIClient(defaultNodes, mainnetHash, {
+				apiClient = new APIClient(defaultNodes, {
 					node: externalTestnetNode,
 				});
 				return expect(apiClient)
@@ -246,21 +221,21 @@ describe('APIClient module', () => {
 
 		describe('randomizeNodes', () => {
 			it('should set randomizeNodes to true when randomizeNodes not explicitly set', () => {
-				apiClient = new APIClient(defaultNodes, mainnetHash, {
+				apiClient = new APIClient(defaultNodes, {
 					randomizeNodes: undefined,
 				});
 				return expect(apiClient).to.have.property('randomizeNodes').be.true;
 			});
 
 			it('should set randomizeNodes to true on initialization when passed as an option', () => {
-				apiClient = new APIClient(defaultNodes, mainnetHash, {
+				apiClient = new APIClient(defaultNodes, {
 					randomizeNodes: true,
 				});
 				return expect(apiClient).to.have.property('randomizeNodes').be.true;
 			});
 
 			it('should set randomizeNodes to false on initialization when passed as an option', () => {
-				apiClient = new APIClient(defaultNodes, mainnetHash, {
+				apiClient = new APIClient(defaultNodes, {
 					randomizeNodes: false,
 				});
 				return expect(apiClient).to.have.property('randomizeNodes').be.false;

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -168,7 +168,7 @@ describe('APIClient module', () => {
 				apiClient.initialize.bind(apiClient, defaultNodes, 'option string'),
 			).to.throw(
 				Error,
-				'APIClient requires the second parameter to be an object.',
+				'APIClient takes an optional object as the second parameter.',
 			);
 		});
 
@@ -177,7 +177,7 @@ describe('APIClient module', () => {
 				apiClient.initialize.bind(apiClient, defaultNodes, []),
 			).to.throw(
 				Error,
-				'APIClient requires the second parameter to be an object.',
+				'APIClient takes an optional object as the second parameter.',
 			);
 		});
 

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -38,10 +38,12 @@ describe('APIClient module', () => {
 	];
 	const defaultHeaders = {
 		'Content-Type': 'application/json',
+		os: 'lisk-js-api',
 	};
 
 	const customHeaders = {
 		'Content-Type': 'application/json',
+		os: 'lisk-js-api',
 		nethash: testnetHash,
 	};
 
@@ -158,6 +160,24 @@ describe('APIClient module', () => {
 			return expect(apiClient.initialize.bind(apiClient, [])).to.throw(
 				Error,
 				'APIClient requires nodes for initialization.',
+			);
+		});
+
+		it('should throw an error if second argument passed to constructor is a string', () => {
+			return expect(
+				apiClient.initialize.bind(apiClient, defaultNodes, 'option string'),
+			).to.throw(
+				Error,
+				'APIClient requires the second parameter to be an object.',
+			);
+		});
+
+		it('should throw an error if second argument passed to constructor is an array', () => {
+			return expect(
+				apiClient.initialize.bind(apiClient, defaultNodes, []),
+			).to.throw(
+				Error,
+				'APIClient requires the second parameter to be an object.',
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?
Although nethash was not required from `core` API, it was required in the APIClient.

### How did I fix it?
Remove `nethash` from required constructor input, and read it from optional field.

### How to test it?
```
const client = elements.APIClient(['http://localhost:4000']);
client.node.getConstants().then(console.log);
```

### Review checklist

* The PR solves #646
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
