### PR TITLE
Refactor constants location and export path - Closes 636

### DIFF
--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -12,14 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import {
-	BETANET_NETHASH,
-	BETANET_NODES,
-	TESTNET_NETHASH,
-	TESTNET_NODES,
-	MAINNET_NETHASH,
-	MAINNET_NODES,
-} from 'lisk-constants';
+import * as constants from './constants';
 import {
 	AccountsResource,
 	BlocksResource,
@@ -61,23 +54,27 @@ export default class APIClient {
 
 	static createMainnetAPIClient(options) {
 		return new APIClient(
-			MAINNET_NODES,
-			Object.assign({}, { nethash: MAINNET_NETHASH }, options),
+			constants.MAINNET_NODES,
+			Object.assign({}, { nethash: constants.MAINNET_NETHASH }, options),
 		);
 	}
 
 	static createTestnetAPIClient(options) {
 		return new APIClient(
-			TESTNET_NODES,
-			Object.assign({}, { nethash: TESTNET_NETHASH }, options),
+			constants.TESTNET_NODES,
+			Object.assign({}, { nethash: constants.TESTNET_NETHASH }, options),
 		);
 	}
 
 	static createBetanetAPIClient(options) {
 		return new APIClient(
-			BETANET_NODES,
-			Object.assign({}, { nethash: BETANET_NETHASH }, options),
+			constants.BETANET_NODES,
+			Object.assign({}, { nethash: constants.BETANET_NETHASH }, options),
 		);
+	}
+
+	static get constants() {
+		return constants;
 	}
 
 	initialize(nodes, providedOptions = {}) {

--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -12,6 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import {
+	MAINNET_NETHASH,
+	TESTNET_NETHASH,
+	BETANET_NETHASH,
+} from 'lisk-constants';
 import * as constants from './constants';
 import {
 	AccountsResource,
@@ -55,21 +60,21 @@ export default class APIClient {
 	static createMainnetAPIClient(options) {
 		return new APIClient(
 			constants.MAINNET_NODES,
-			Object.assign({}, { nethash: constants.MAINNET_NETHASH }, options),
+			Object.assign({}, { nethash: MAINNET_NETHASH }, options),
 		);
 	}
 
 	static createTestnetAPIClient(options) {
 		return new APIClient(
 			constants.TESTNET_NODES,
-			Object.assign({}, { nethash: constants.TESTNET_NETHASH }, options),
+			Object.assign({}, { nethash: TESTNET_NETHASH }, options),
 		);
 	}
 
 	static createBetanetAPIClient(options) {
 		return new APIClient(
 			constants.BETANET_NODES,
-			Object.assign({}, { nethash: constants.BETANET_NETHASH }, options),
+			Object.assign({}, { nethash: BETANET_NETHASH }, options),
 		);
 	}
 

--- a/src/api_client/constants.js
+++ b/src/api_client/constants.js
@@ -16,3 +16,25 @@ export const GET = 'GET';
 export const POST = 'POST';
 export const PUT = 'PUT';
 export const API_RECONNECT_MAX_RETRY_COUNT = 3;
+
+export const BETANET_NETHASH =
+	'ef3844327d1fd0fc5785291806150c937797bdb34a748c9cd932b7e859e9ca0c';
+export const BETANET_NODES = [
+	'http://94.237.42.109:5000',
+	'http://83.136.252.99:5000',
+];
+export const TESTNET_NETHASH =
+	'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba';
+export const TESTNET_NODES = ['http://testnet.lisk.io:7000'];
+export const MAINNET_NETHASH =
+	'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511';
+export const MAINNET_NODES = [
+	'https://node01.lisk.io:443',
+	'https://node02.lisk.io:443',
+	'https://node03.lisk.io:443',
+	'https://node04.lisk.io:443',
+	'https://node05.lisk.io:443',
+	'https://node06.lisk.io:443',
+	'https://node07.lisk.io:443',
+	'https://node08.lisk.io:443',
+];

--- a/src/api_client/constants.js
+++ b/src/api_client/constants.js
@@ -17,17 +17,11 @@ export const POST = 'POST';
 export const PUT = 'PUT';
 export const API_RECONNECT_MAX_RETRY_COUNT = 3;
 
-export const BETANET_NETHASH =
-	'ef3844327d1fd0fc5785291806150c937797bdb34a748c9cd932b7e859e9ca0c';
 export const BETANET_NODES = [
 	'http://94.237.42.109:5000',
 	'http://83.136.252.99:5000',
 ];
-export const TESTNET_NETHASH =
-	'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba';
 export const TESTNET_NODES = ['http://testnet.lisk.io:7000'];
-export const MAINNET_NETHASH =
-	'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511';
 export const MAINNET_NODES = [
 	'https://node01.lisk.io:443',
 	'https://node02.lisk.io:443',

--- a/src/lisk-constants/index.js
+++ b/src/lisk-constants/index.js
@@ -20,25 +20,3 @@ export const EPOCH_TIME_SECONDS = Math.floor(EPOCH_TIME.getTime() / 1000);
 export const MAX_ADDRESS_NUMBER = '18446744073709551615';
 // Largest possible amount. Derived from bignum.fromBuffer(Buffer.from(new Array(8).fill(255))).
 export const MAX_TRANSACTION_AMOUNT = '18446744073709551615';
-
-export const BETANET_NETHASH =
-	'ef3844327d1fd0fc5785291806150c937797bdb34a748c9cd932b7e859e9ca0c';
-export const BETANET_NODES = [
-	'http://94.237.42.109:5000',
-	'http://83.136.252.99:5000',
-];
-export const TESTNET_NETHASH =
-	'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba';
-export const TESTNET_NODES = ['http://testnet.lisk.io:7000'];
-export const MAINNET_NETHASH =
-	'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511';
-export const MAINNET_NODES = [
-	'https://node01.lisk.io:443',
-	'https://node02.lisk.io:443',
-	'https://node03.lisk.io:443',
-	'https://node04.lisk.io:443',
-	'https://node05.lisk.io:443',
-	'https://node06.lisk.io:443',
-	'https://node07.lisk.io:443',
-	'https://node08.lisk.io:443',
-];

--- a/src/lisk-constants/index.js
+++ b/src/lisk-constants/index.js
@@ -20,3 +20,10 @@ export const EPOCH_TIME_SECONDS = Math.floor(EPOCH_TIME.getTime() / 1000);
 export const MAX_ADDRESS_NUMBER = '18446744073709551615';
 // Largest possible amount. Derived from bignum.fromBuffer(Buffer.from(new Array(8).fill(255))).
 export const MAX_TRANSACTION_AMOUNT = '18446744073709551615';
+
+export const BETANET_NETHASH =
+	'ef3844327d1fd0fc5785291806150c937797bdb34a748c9cd932b7e859e9ca0c';
+export const TESTNET_NETHASH =
+	'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba';
+export const MAINNET_NETHASH =
+	'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511';

--- a/src/transactions/index.js
+++ b/src/transactions/index.js
@@ -20,6 +20,7 @@ import registerMultisignature from './4_register_multisignature_account';
 import createDapp from './5_create_dapp';
 import createSignatureObject from './create_signature_object';
 import * as utils from './utils';
+import * as constants from './constants';
 
 export default {
 	transfer,
@@ -30,4 +31,5 @@ export default {
 	createSignatureObject,
 	createDapp,
 	utils,
+	constants,
 };

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -141,6 +141,12 @@ describe('APIClient module', () => {
 		});
 	});
 
+	describe('#constants', () => {
+		it('should return APIClient instance', () => {
+			return expect(APIClient.constants).to.be.an('object');
+		});
+	});
+
 	describe('#initialize', () => {
 		it('should throw an error if no arguments are passed to constructor', () => {
 			return expect(apiClient.initialize.bind(apiClient)).to.throw(

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -142,7 +142,7 @@ describe('APIClient module', () => {
 	});
 
 	describe('#constants', () => {
-		it('should return APIClient instance', () => {
+		it('should expose API constants', () => {
 			return expect(APIClient.constants).to.be.an('object');
 		});
 	});

--- a/test/api_client/constants.js
+++ b/test/api_client/constants.js
@@ -17,11 +17,8 @@ import {
 	POST,
 	PUT,
 	API_RECONNECT_MAX_RETRY_COUNT,
-	BETANET_NETHASH,
 	BETANET_NODES,
-	TESTNET_NETHASH,
 	TESTNET_NODES,
-	MAINNET_NETHASH,
 	MAINNET_NODES,
 } from 'api_client/constants';
 
@@ -42,26 +39,14 @@ describe('api constants module', () => {
 		return expect(API_RECONNECT_MAX_RETRY_COUNT).to.be.an.integer;
 	});
 
-	it('BETANET_NETHASH should be a string', () => {
-		return expect(BETANET_NETHASH).to.be.a('string');
-	});
-
 	it('BETANET_NODES should be an array of strings', () => {
 		expect(BETANET_NODES).to.be.an('array');
 		return BETANET_NODES.forEach(node => expect(node).to.be.a('string'));
 	});
 
-	it('TESTNET_NETHASH should be a string', () => {
-		return expect(TESTNET_NETHASH).to.be.a('string');
-	});
-
 	it('TESTNET_NODES should be an array of strings', () => {
 		expect(TESTNET_NODES).to.be.an('array');
 		return TESTNET_NODES.forEach(node => expect(node).to.be.a('string'));
-	});
-
-	it('MAINNET_NETHASH should be a string', () => {
-		return expect(MAINNET_NETHASH).to.be.a('string');
 	});
 
 	it('MAINNET_NODES should be an array of strings', () => {

--- a/test/api_client/constants.js
+++ b/test/api_client/constants.js
@@ -17,6 +17,12 @@ import {
 	POST,
 	PUT,
 	API_RECONNECT_MAX_RETRY_COUNT,
+	BETANET_NETHASH,
+	BETANET_NODES,
+	TESTNET_NETHASH,
+	TESTNET_NODES,
+	MAINNET_NETHASH,
+	MAINNET_NODES,
 } from 'api_client/constants';
 
 describe('api constants module', () => {
@@ -34,5 +40,32 @@ describe('api constants module', () => {
 
 	it('API_RECONNECT_MAX_RETRY_COUNT should be an integer', () => {
 		return expect(API_RECONNECT_MAX_RETRY_COUNT).to.be.an.integer;
+	});
+
+	it('BETANET_NETHASH should be a string', () => {
+		return expect(BETANET_NETHASH).to.be.a('string');
+	});
+
+	it('BETANET_NODES should be an array of strings', () => {
+		expect(BETANET_NODES).to.be.an('array');
+		return BETANET_NODES.forEach(node => expect(node).to.be.a('string'));
+	});
+
+	it('TESTNET_NETHASH should be a string', () => {
+		return expect(TESTNET_NETHASH).to.be.a('string');
+	});
+
+	it('TESTNET_NODES should be an array of strings', () => {
+		expect(TESTNET_NODES).to.be.an('array');
+		return TESTNET_NODES.forEach(node => expect(node).to.be.a('string'));
+	});
+
+	it('MAINNET_NETHASH should be a string', () => {
+		return expect(MAINNET_NETHASH).to.be.a('string');
+	});
+
+	it('MAINNET_NODES should be an array of strings', () => {
+		expect(MAINNET_NODES).to.be.an('array');
+		return MAINNET_NODES.forEach(node => expect(node).to.be.a('string'));
 	});
 });

--- a/test/lisk-constants/index.js
+++ b/test/lisk-constants/index.js
@@ -18,12 +18,6 @@ import {
 	EPOCH_TIME_MILLISECONDS,
 	MAX_ADDRESS_NUMBER,
 	MAX_TRANSACTION_AMOUNT,
-	BETANET_NETHASH,
-	BETANET_NODES,
-	TESTNET_NETHASH,
-	TESTNET_NODES,
-	MAINNET_NETHASH,
-	MAINNET_NODES,
 } from 'lisk-constants';
 
 describe('lisk-constants', () => {
@@ -45,32 +39,5 @@ describe('lisk-constants', () => {
 
 	it('MAX_TRANSACTION_AMOUNT should be a string', () => {
 		return expect(MAX_TRANSACTION_AMOUNT).to.be.a('string');
-	});
-
-	it('BETANET_NETHASH should be a string', () => {
-		return expect(BETANET_NETHASH).to.be.a('string');
-	});
-
-	it('BETANET_NODES should be an array of strings', () => {
-		expect(BETANET_NODES).to.be.an('array');
-		return BETANET_NODES.forEach(node => expect(node).to.be.a('string'));
-	});
-
-	it('TESTNET_NETHASH should be a string', () => {
-		return expect(TESTNET_NETHASH).to.be.a('string');
-	});
-
-	it('TESTNET_NODES should be an array of strings', () => {
-		expect(TESTNET_NODES).to.be.an('array');
-		return TESTNET_NODES.forEach(node => expect(node).to.be.a('string'));
-	});
-
-	it('MAINNET_NETHASH should be a string', () => {
-		return expect(MAINNET_NETHASH).to.be.a('string');
-	});
-
-	it('MAINNET_NODES should be an array of strings', () => {
-		expect(MAINNET_NODES).to.be.an('array');
-		return MAINNET_NODES.forEach(node => expect(node).to.be.a('string'));
 	});
 });

--- a/test/lisk-constants/index.js
+++ b/test/lisk-constants/index.js
@@ -18,6 +18,9 @@ import {
 	EPOCH_TIME_MILLISECONDS,
 	MAX_ADDRESS_NUMBER,
 	MAX_TRANSACTION_AMOUNT,
+	BETANET_NETHASH,
+	TESTNET_NETHASH,
+	MAINNET_NETHASH,
 } from 'lisk-constants';
 
 describe('lisk-constants', () => {
@@ -39,5 +42,17 @@ describe('lisk-constants', () => {
 
 	it('MAX_TRANSACTION_AMOUNT should be a string', () => {
 		return expect(MAX_TRANSACTION_AMOUNT).to.be.a('string');
+	});
+
+	it('BETANET_NETHASH should be a string', () => {
+		return expect(BETANET_NETHASH).to.be.a('string');
+	});
+
+	it('TESTNET_NETHASH should be a string', () => {
+		return expect(TESTNET_NETHASH).to.be.a('string');
+	});
+
+	it('MAINNET_NETHASH should be a string', () => {
+		return expect(MAINNET_NETHASH).to.be.a('string');
 	});
 });

--- a/test/transactions/index.js
+++ b/test/transactions/index.js
@@ -57,5 +57,17 @@ describe('transaction', () => {
 				.to.have.property('createSignatureObject')
 				.and.be.a('function');
 		});
+
+		it('should have #utils', () => {
+			return expect(transaction)
+				.to.have.property('utils')
+				.and.be.an('object');
+		});
+
+		it('should have #constants', () => {
+			return expect(transaction)
+				.to.have.property('constants')
+				.and.be.an('object');
+		});
 	});
 });


### PR DESCRIPTION
### What was the problem?
transaction constant was not exposed, and constants that are used only in APIClient was in general constants

### How did I fix it?
Expose constants from transaction
Expose APIClient constants

### How to test it?
```
elements.transaction.constants;
elements.APICleint.constants;
```

### Review checklist

* The PR solves #636 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
