### PR TITLE
Only build for node in prestart script - Closes #652

### DIFF
--- a/bin/prestart.sh
+++ b/bin/prestart.sh
@@ -1,5 +1,5 @@
 read -r -p $'\e[96mDo you want to build LiskJS first? [y/N]\e[0m ' should_build
 if [[ $should_build =~ ^[Yy]$ ]]
 then
-	npm run build
+	npm run build:node
 fi


### PR DESCRIPTION
### What was the problem?

We built everything prestart, even though only building for node was needed.

### How did I fix it?

Changed `npm run build` to `npm run build:node` in the prestart script.

### How to test it?

`npm start` then `y` to build.

### Review checklist

* The PR solves #652 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
