### PR TITLE
Change GCM iv to default

### DIFF
--- a/src/cryptography/encrypt.js
+++ b/src/cryptography/encrypt.js
@@ -105,7 +105,7 @@ const getKeyFromPassword = (password, salt) =>
 	);
 
 const encryptAES256GCMWithPassword = (plainText, password) => {
-	const iv = crypto.randomBytes(16);
+	const iv = crypto.randomBytes(12);
 	const salt = crypto.randomBytes(16);
 	const key = getKeyFromPassword(password, salt);
 


### PR DESCRIPTION
GCM iv by default should be 12 bytes. Additionally it appears that's inconsistency between core and lisk-js. I've seen 12bytes iv's in core test configs.
